### PR TITLE
Use default track in uploads

### DIFF
--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -35,7 +35,7 @@ runs:
 
         if [ -n "${{ github.event.number }}" ]; then
           echo "Triggered from a PR"
-          channel="latest/edge/pr-${{ github.event.number }}"
+          channel="edge/pr-${{ github.event.number }}"
         fi
 
         echo "Uploading to channel: $channel"


### PR DESCRIPTION
This is so that the revision gets uploaded to the default track, instead of always to `latest`.