### PR TITLE
Rework publish channels

### DIFF
--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -1,8 +1,11 @@
 name: Publish snap
 description: >
   Publish a snap and its components to a channel in the Snap Store.
-  When triggered from a PR, the channel is set to `latest/edge/pr-<pr-num>`,
-  otherwise, it is set to `latest/edge/<short-git-hash>`.
+  
+  The channel is set based on the tigger:
+  - Git main branch: <track>/edge
+  - Other git branches: <track>/edge/<branch>
+  - PR: <tracklatest/edge/pr-<pr-num>
 
 inputs:
   store-credentials:
@@ -36,18 +39,18 @@ runs:
         # Construct the snap channel
         channel_track="${{ inputs.snap-track }}"
         channel_risk="edge"
-        channel_branch="$(git rev-parse --short HEAD)"
+        channel="$channel_track/$channel_risk
 
-        echo "Branch name: ${{ github.ref_name }}"
-        echo "Event number: ${{ github.event.number }}"
+        # Triggered from a branch other than main
+        # TBA: use git branch in channel branch
 
-        # If triggered from a PR, use a different branch name
+        # Triggered from a PR
         if [ -n "${{ github.event.number }}" ]; then
           echo "Triggered from PR: ${{ github.event.number }}"
           channel_branch="pr-${{ github.event.number }}"
+          channel+="/$channel_branch"
         fi
 
-        channel="$channel_track/$channel_risk/$channel_branch"
         echo "Using channel: $channel"
 
         "${{ github.action_path }}/upload.sh" "$channel"

--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -39,18 +39,16 @@ runs:
         # Construct the snap channel
         channel_track="${{ inputs.snap-track }}"
         channel_risk="edge"
-        channel="$channel_track/$channel_risk
 
-        # Triggered from a branch other than main
-        # TBA: use git branch in channel branch
-
-        # Triggered from a PR
-        if [ -n "${{ github.event.number }}" ]; then
+        if [ -n "${{ github.event.number }}" ]; then 
           echo "Triggered from PR: ${{ github.event.number }}"
           channel_branch="pr-${{ github.event.number }}"
-          channel+="/$channel_branch"
+        else
+          echo "Triggered from branch: ${{ github.ref_name }}"
+          channel_branch="${{ github.ref_name }}"
         fi
 
+        channel="$channel_track/$channel_risk/$channel_branch"
         echo "Using channel: $channel"
 
         "${{ github.action_path }}/upload.sh" "$channel"

--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -2,10 +2,9 @@ name: Publish snap
 description: >
   Publish a snap and its components to a channel in the Snap Store.
   
-  The channel is set based on the tigger:
-  - Git main branch: <track>/edge
-  - Other git branches: <track>/edge/<branch>
-  - PR: <tracklatest/edge/pr-<pr-num>
+  The channel is set based on the trigger:
+  - PR: <track>/edge/pr-<pr-num>
+  - Not a PR: <track>/edge/<branch>
 
 inputs:
   store-credentials:


### PR DESCRIPTION
The action currently sets the channel to `<track>/edge/pr-<pr-num>` when triggered from a PR, otherwise to `<track>/edge/<short-git-hash>`.

Instead, builds from main should be published to edge.