### PR TITLE
Get api url from status command

### DIFF
--- a/tests/testflinger/agent.sh
+++ b/tests/testflinger/agent.sh
@@ -99,7 +99,10 @@ _run snap run --shell "$SNAP_NAME" "/snap/$SNAP_NAME/current/bin/wait-for-server
 echo "::endgroup::"
 
 echo "::group::Running benchmark"
-benchmark_result=$(_run "cd llmapibenchmark/cmd && DEBUG=true go run . --base-url=http://localhost:8080/v1 --concurrency=1 --format=json")
+status_json=$(_run qwen-vl status --format=json)
+api_url=$(echo "$status_json" | jq -r '.endpoints.openai')
+echo "API URL: $api_url"
+benchmark_result=$(_run "cd llmapibenchmark/cmd && DEBUG=true go run . --base-url=$api_url --concurrency=1 --format=json")
 echo "$benchmark_result"
 
 result_tps=$(echo "$benchmark_result" | jq .results[0].generation_speed)


### PR DESCRIPTION
Testflinger agent script get API URL from status command

Related:
* Resolves #13 
* Qwen test run: https://github.com/canonical/qwen-vl-snap/actions/runs/18647053783/job/53156478264
