### PR TITLE
Action upload allow git version hash

### DIFF
--- a/actions/publish/upload.sh
+++ b/actions/publish/upload.sh
@@ -18,10 +18,9 @@ fi
 
 # load snapcraft.yaml into variable, explode to evaluate aliases
 snapcraft_yaml=$(yq '. | explode(.)' snap/snapcraft.yaml)
-
 snap_name=$(echo "$snapcraft_yaml" | yq '.name')
-snap_version=$(echo "$snapcraft_yaml" | yq '.version')
-snap_file="${snap_name}_${snap_version}_${arch}.snap"
+
+snap_file=$(ls "$snap_name"_*_"$arch".snap)
 check_file "$snap_file"
 snap_size=$(du -h "$snap_file" | cut -f1)
 
@@ -34,8 +33,7 @@ components=$(echo "$snapcraft_yaml" | yq '.components | to_entries | .[].key')
 component_args=()
 echo "Snap components:"
 for comp_name in $components; do
-    comp_ver=$(echo "$snapcraft_yaml" | yq ".components.$comp_name.version")
-    comp_file="${snap_name}+${comp_name}_${comp_ver}.comp"
+    comp_file=$(ls "$snap_name"+"$comp_name"_*.comp)
     check_file "$comp_file"
     comp_size=$(du -h "$comp_file" | cut -f1)
     echo -e "\t$comp_file $comp_size"


### PR DESCRIPTION
Github publish action use wildcard to find snap and component file names, rather than looking up the version from the snapcraft.yaml file. This is required for snaps and components with versions that are dynamically assigned, like via git hashes.

Because this is running in a worker, the directory should only contain files from the current build. If multiple snaps or components with the same name, but different versions are found, an error will be raised by the `check_file()` function.