### PR TITLE
Add reusable workflow to build and publish snaps

### DIFF
--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -1,0 +1,59 @@
+name: Build and publish snap
+
+on:
+  workflow_call:
+    inputs:
+      build-sha:
+        # When triggered by pull_request_target, checkout PR's HEAD (rather than base), otherwise use github.sha
+        required: true
+        type: string
+      publish-channel:
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: Build and publish snap
+    strategy:
+      fail-fast: false
+      matrix:
+        runs:
+          - architecture: amd64
+            runner: [ self-hosted, linux, amd64, xlarge, noble ]
+          - architecture: arm64
+            runner: [ self-hosted, linux, arm64, xlarge, noble ]
+    runs-on: ${{ matrix.runs.runner }}
+
+    steps:
+      # Update snapd as we need a recent one to support components
+      - name: Update snapd
+        run: |
+          sudo snap refresh snapd
+
+      - name: Install Git LFS
+        run: sudo apt-get update && sudo apt-get install -y git-lfs
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          lfs: true
+          submodules: true
+          ref: ${{ inputs.build-sha }}
+
+      - name: Prepare models
+        run: |
+          # Expect a prepare-models.sh script in the repo root
+          if [ -f "prepare-models.sh" ]; then
+            ./prepare-models.sh
+          fi
+
+      - name: Build snap
+        uses: canonical/action-build@v1
+
+      # Requires STORE_LOGIN secret set. Export with:
+      # snapcraft export-login --snaps gemma3 --channels */edge/* --acls package_access,package_push,package_update,package_release --expires 2026-11-01T00:00:00Z <file>
+      - name: Publish snap
+        uses: canonical/inference-snaps-dev/actions/publish@IENG-1891-refactor-ci
+        with:
+          store-credentials: ${{ secrets.STORE_LOGIN }}
+          publish-channel: ${{ inputs.publish-channel }}

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -10,6 +10,10 @@ on:
       publish-channel:
         required: true
         type: string
+      init-build-script:
+        description: If set, run this script before building the snap. It initializes the build environment, like downloading resources.
+        required: false
+        type: string
     secrets:
       store-credentials:
         required: true
@@ -43,11 +47,10 @@ jobs:
           submodules: true
           ref: ${{ inputs.build-sha }}
 
-      - name: Prepare models
+      - name: Init build environment
         run: |
-          # Expect a prepare-models.sh script in the repo root
-          if [ -f "prepare-models.sh" ]; then
-            ./prepare-models.sh
+          if [ -n "${{ inputs.init-build-script }}" ]; then
+            ./"${{ inputs.init-build-script }}"
           fi
 
       - name: Build snap

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -11,7 +11,7 @@ on:
         required: true
         type: string
     secrets:
-      STORE_LOGIN:
+      store-credentials:
         required: true
 
 jobs:
@@ -53,10 +53,9 @@ jobs:
       - name: Build snap
         uses: canonical/action-build@v1
 
-      # Requires STORE_LOGIN secret set. Export with:
-      # snapcraft export-login --snaps gemma3 --channels */edge/* --acls package_access,package_push,package_update,package_release --expires 2026-11-01T00:00:00Z <file>
+      # Requires the store-credentials secret set by the calling workflow
       - name: Publish snap
         uses: canonical/inference-snaps-dev/actions/publish@IENG-1891-refactor-ci
         with:
-          store-credentials: ${{ secrets.STORE_LOGIN }}
+          store-credentials: ${{ secrets.store-credentials }}
           publish-channel: ${{ inputs.publish-channel }}

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -10,6 +10,9 @@ on:
       publish-channel:
         required: true
         type: string
+    secrets:
+      STORE_LOGIN:
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: Build and publish snap
+    name: Build & publish
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -1,4 +1,4 @@
-name: Trigger workflow by label
+name: Remove label
 
 on:
   workflow_call:

--- a/.github/workflows/trigger-by-label.yaml
+++ b/.github/workflows/trigger-by-label.yaml
@@ -1,0 +1,24 @@
+name: Trigger workflow by label
+
+on:
+  workflow_call:
+
+jobs:
+  trigger:
+    name: Trigger workflow and remove label
+    if: github.event.label.name == 'trigger-build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # needed to comment on PR
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        # Need to check out the repo as the gh cli needs it for context
+
+      - name: Remove 'trigger-build' label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          gh pr edit $PR_NUMBER --remove-label "trigger-build"

--- a/.github/workflows/trigger-by-label.yaml
+++ b/.github/workflows/trigger-by-label.yaml
@@ -4,8 +4,8 @@ on:
   workflow_call:
 
 jobs:
-  trigger:
-    name: Trigger workflow and remove label
+  remove-label:
+    name: Remove label
     if: github.event.label.name == 'trigger-build'
     runs-on: ubuntu-latest
     permissions:

--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -1,8 +1,6 @@
 name: Publish snap
 description: >
-  Publish a snap and its components to a channel in the Snap Store.
-  When triggered from a PR, the channel is set to `latest/edge/pr-<pr-num>`,
-  otherwise, it is set to `latest/edge/<short-git-hash>`.
+  Publish a snap and its components to a specified channel in the Snap Store.
 
 inputs:
   store-credentials:
@@ -13,9 +11,9 @@ inputs:
       its components to Snap Store.
     default: ''
     required: true
-  snap-track:
-    description: The snap channel's track
-    default: 'latest'
+  publish-channel:
+    description: The channel where the snap should be published.
+    default: ''
     required: true
 
 runs:
@@ -33,21 +31,11 @@ runs:
           exit 1
         fi
 
-        # Construct the snap channel
-        channel_track="${{ inputs.snap-track }}"
-        channel_risk="edge"
-        channel_branch="$(git rev-parse --short HEAD)"
-
-        echo "Branch name: ${{ github.ref_name }}"
-        echo "Event number: ${{ github.event.number }}"
-
-        # If triggered from a PR, use a different branch name
-        if [ -n "${{ github.event.number }}" ]; then
-          echo "Triggered from PR: ${{ github.event.number }}"
-          channel_branch="pr-${{ github.event.number }}"
+        channel="${{ inputs.publish-channel }}"
+        if [ -z "$channel" ]; then
+          echo "publish-channel is not set."
+          exit 1
         fi
-
-        channel="$channel_track/$channel_risk/$channel_branch"
         echo "Using channel: $channel"
 
         "${{ github.action_path }}/upload.sh" "$channel"


### PR DESCRIPTION
* Add a reusable workflow for checking for the `trigger-build` label, and removing the label
* Add a reusable workflow that does a matrix build and publish of the snap on amd64 and arm64
* Remove snap channel logic from publish channel, and replace by explicit channel form a required input configuration

Workflow run that uses these changes: https://github.com/canonical/gemma3-snap/actions/runs/19966677808