### PR TITLE
Minor refactoring in workflows and actions

### DIFF
--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -3,15 +3,11 @@ name: Build and publish snap
 on:
   workflow_call:
     inputs:
-      build-sha:
-        # When triggered by pull_request_target, checkout PR's HEAD (rather than base), otherwise use github.sha
-        required: true
-        type: string
       publish-channel:
         required: true
         type: string
       init-build-script:
-        description: If set, run this script before building the snap. It initializes the build environment, like downloading resources.
+        description: Script to run before building the snap
         required: false
         type: string
     secrets:
@@ -45,7 +41,6 @@ jobs:
         with:
           lfs: true
           submodules: true
-          ref: ${{ inputs.build-sha }}
 
       - name: Init build environment
         run: |

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -58,7 +58,7 @@ jobs:
 
       # Requires the store-credentials secret set by the calling workflow
       - name: Publish snap
-        uses: canonical/inference-snaps-dev/actions/publish@IENG-1891-refactor-ci
+        uses: ./actions/publish
         with:
           store-credentials: ${{ secrets.store-credentials }}
           publish-channel: ${{ inputs.publish-channel }}

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -20,12 +20,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs:
-          - architecture: amd64
-            runner: [ self-hosted, linux, amd64, xlarge, noble ]
-          - architecture: arm64
-            runner: [ self-hosted, linux, arm64, xlarge, noble ]
-    runs-on: ${{ matrix.runs.runner }}
+        runner:
+          - [ self-hosted, linux, amd64, xlarge, noble ]
+          - [ self-hosted, linux, arm64, xlarge, noble ]
+    runs-on: ${{ matrix.runner }}
 
     steps:
       # Update snapd as we need a recent one to support components

--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -2,11 +2,16 @@ name: Remove label
 
 on:
   workflow_call:
+    inputs:
+      label:
+        description: The name of the label that gets removed
+        required: true
+        type: string
 
 jobs:
   remove-label:
     name: Remove label
-    if: github.event.label.name == 'trigger-build'
+    if: github.event.label.name == inputs.label
     runs-on: ubuntu-latest
 
     steps:
@@ -14,9 +19,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         
-      - name: Remove 'trigger-build' label
+      - name: Remove label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          gh pr edit $PR_NUMBER --remove-label "trigger-build"
+          gh pr edit $PR_NUMBER --remove-label "${{ inputs.label }}"

--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -8,14 +8,12 @@ jobs:
     name: Remove label
     if: github.event.label.name == 'trigger-build'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write # needed to comment on PR
+
     steps:
+      # Checkout the repo as the gh cli needs it for context
       - name: Checkout code
         uses: actions/checkout@v6
-        # Need to check out the repo as the gh cli needs it for context
-
+        
       - name: Remove 'trigger-build' label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/actions/publish/action.yml
+++ b/actions/publish/action.yml
@@ -4,16 +4,10 @@ description: >
 
 inputs:
   store-credentials:
-    description: >
-      The Snapcraft store credentials to use
-
-      This parameter is required to publish a snap and
-      its components to Snap Store.
-    default: ''
+    description: Snap Store credentials
     required: true
   publish-channel:
-    description: The channel where the snap should be published.
-    default: ''
+    description: The channel where the snap should be published
     required: true
 
 runs:
@@ -31,11 +25,6 @@ runs:
           exit 1
         fi
 
-        channel="${{ inputs.publish-channel }}"
-        if [ -z "$channel" ]; then
-          echo "publish-channel is not set."
-          exit 1
-        fi
         echo "Using channel: $channel"
 
         "${{ github.action_path }}/upload.sh" "$channel"


### PR DESCRIPTION
Use relative path for action to avoid versioning.

Remove extra permissions that aren't required for commenting.
Remove control of source reference, which is only needed in case the caller workflow uses pull_request_target. That is not necessary for granting permissions to comment.

Remove unwanted defaults, leading to skipped workflow usage errors.

Pass label name from the caller.