### PR TITLE
Remove extra permissions, add label to inputs

### DIFF
--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -3,10 +3,6 @@ name: Build and publish snap
 on:
   workflow_call:
     inputs:
-      build-sha:
-        # When triggered by pull_request_target, checkout PR's HEAD (rather than base), otherwise use github.sha
-        required: true
-        type: string
       publish-channel:
         required: true
         type: string
@@ -45,7 +41,6 @@ jobs:
         with:
           lfs: true
           submodules: true
-          ref: ${{ inputs.build-sha }}
 
       - name: Init build environment
         run: |

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -22,12 +22,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs:
-          - architecture: amd64
-            runner: [ self-hosted, linux, amd64, xlarge, noble ]
-          - architecture: arm64
-            runner: [ self-hosted, linux, arm64, xlarge, noble ]
-    runs-on: ${{ matrix.runs.runner }}
+        runner:
+          - [ self-hosted, linux, amd64, xlarge, noble ]
+          - [ self-hosted, linux, arm64, xlarge, noble ]
+    runs-on: ${{ matrix.runner }}
 
     steps:
       # Update snapd as we need a recent one to support components

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -4,14 +4,16 @@ on:
   workflow_call:
     inputs:
       publish-channel:
+        description: Snap Store channel for publishing the snap
         required: true
         type: string
       init-build-script:
-        description: If set, run this script before building the snap. It initializes the build environment, like downloading resources.
+        description: Script to run before building the snap
         required: false
         type: string
     secrets:
       store-credentials:
+        description: Snap Store credentials for publishing the snap to the specified channel
         required: true
 
 jobs:

--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -8,9 +8,6 @@ jobs:
     name: Remove label
     if: github.event.label.name == 'trigger-build'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write # needed to comment on PR
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -2,20 +2,25 @@ name: Remove label
 
 on:
   workflow_call:
+    inputs:
+      label:
+        description: The name of the label that gets removed
+        required: true
+        type: string
 
 jobs:
   remove-label:
     name: Remove label
-    if: github.event.label.name == 'trigger-build'
+    if: github.event.label.name == inputs.label
     runs-on: ubuntu-latest
     steps:
+      # Checkout the repo as the gh cli needs it for context
       - name: Checkout code
         uses: actions/checkout@v6
-        # Need to check out the repo as the gh cli needs it for context
 
-      - name: Remove 'trigger-build' label
+      - name: Remove label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          gh pr edit $PR_NUMBER --remove-label "trigger-build"
+          gh pr edit $PR_NUMBER --remove-label "${{ inputs.label }}"


### PR DESCRIPTION
Remove extra permissions that aren't required for commenting. 

Remove build-sha input. It was needed when caller was triggered by pull_request_target.

Pass label name from the caller.

Tested with https://github.com/canonical/gemma3-snap/pull/37