### PR TITLE
Update self-hosted runners

### DIFF
--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - [ self-hosted, linux, amd64, xlarge, noble ]
-          - [ self-hosted, linux, arm64, xlarge, noble ]
+          - self-hosted-linux-amd64-noble-xlarge
+          - self-hosted-linux-arm64-noble-large-extra
     runs-on: ${{ matrix.runner }}
 
     steps:


### PR DESCRIPTION
Use the new arm64 runner with extra disk space. Use a single label for the runner as recommended in the [docs](https://canonical-self-hosted-github-runner-docs.readthedocs-hosted.com/en/latest/usage/available_runners/#:~:text=We%20recommend%20using%20the%20single%20label).

PR to test this change: https://github.com/canonical/nemotron-3-nano-snap/pull/15

Workflow using the new runner: https://github.com/canonical/nemotron-3-nano-snap/actions/runs/21580865233/job/62186352091

This PR only bumps the disk size for arm64. We need to add back the code on nemotron that allows the `-dirty` in the version, and then test the build again. If it fails on amd64, we need to bump that runner to the `-extra` size too.

Workflow with `-dirty` added back: https://github.com/canonical/nemotron-3-nano-snap/actions/runs/21588255380?pr=15