### PR TITLE
Make build runners configurable

### DIFF
--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -3,6 +3,11 @@ name: Build and publish snap
 on:
   workflow_call:
     inputs:
+      runner:
+        description: The type of machine to run the job on
+        required: true
+        type: string
+        default: '[ self-hosted, linux, amd64, xlarge, noble ]'
       publish-channel:
         description: Snap Store channel for publishing the snap
         required: true
@@ -19,13 +24,7 @@ on:
 jobs:
   build:
     name: Build & publish
-    strategy:
-      fail-fast: false
-      matrix:
-        runner:
-          - [ self-hosted, linux, amd64, xlarge, noble ]
-          - [ self-hosted, linux, arm64, xlarge, noble ]
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ fromJSON(inputs.runner) }}
 
     steps:
       # Update snapd as we need a recent one to support components

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -4,10 +4,13 @@ on:
   workflow_call:
     inputs:
       runner:
-        description: The type of machine to run the job on
+        description: |
+          The type of machine to run the job on.
+          The input should be a JSON string or array. For example:
+          - '"ubuntu-latest"' for a single label
+          - '[ "self-hosted", "amd64", "large" ]' for multiple labels
         required: true
         type: string
-        default: '[ "self-hosted", "amd64", "xlarge" ]'
       publish-channel:
         description: Snap Store channel for publishing the snap
         required: true

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -12,7 +12,6 @@ on:
           - '[ "self-hosted", "amd64", "large" ]' for multiple labels
 
           Note: Using GH-hosted runners is currently not possible; see https://github.com/canonical/inference-snaps-dev/issues/40
-        required: true
         type: string
         default: '[ "self-hosted", "amd64", "xlarge", "noble" ]'
       publish-channel:

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -14,6 +14,7 @@ on:
           Note: Using GH-hosted runners is currently not possible; see https://github.com/canonical/inference-snaps-dev/issues/40
         required: true
         type: string
+        default: '[ "self-hosted", "amd64", "xlarge", "noble" ]'
       publish-channel:
         description: Snap Store channel for publishing the snap
         required: true

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -6,9 +6,12 @@ on:
       runner:
         description: |
           The type of machine to run the job on.
+          
           The input should be a JSON string or array. For example:
           - '"ubuntu-latest"' for a single label
           - '[ "self-hosted", "amd64", "large" ]' for multiple labels
+
+          Note: Using GH-hosted runners is currently not possible; see https://github.com/canonical/inference-snaps-dev/issues/40
         required: true
         type: string
       publish-channel:

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -7,7 +7,7 @@ on:
         description: The type of machine to run the job on
         required: true
         type: string
-        default: '[ self-hosted, linux, amd64, xlarge, noble ]'
+        default: '[ "self-hosted", "amd64", "xlarge" ]'
       publish-channel:
         description: Snap Store channel for publishing the snap
         required: true


### PR DESCRIPTION
Remove runners from reusable build and publish workflow, and make them configurable from the caller.

Usage example:
```yaml
  build-and-publish:
    uses: canonical/inference-snaps-dev/.github/workflows/build-publish-snap.yaml@v2
    strategy:
      fail-fast: false
      matrix:
        runner:
          - [ self-hosted, amd64, noble ]
          - [ self-hosted, arm64, noble ]
    with:
      runner: "${{ toJSON(matrix.runner) }}"
```

I believe it could also work by escaping:
```yaml
  build-and-publish:
    uses: canonical/inference-snaps-dev/.github/workflows/build-publish-snap.yaml@v2
    strategy:
      fail-fast: false
      matrix:
        runner:
          - "[ \"self-hosted\", \"amd64\", \"noble\" ]"
          - "[ \"self-hosted\", \"arm64\", \"noble\" ]"
    with:
      runner: matrix.runner
```

Need to document this for the workflow along with others.