### PR TITLE
Prevent an error if no components are being built

### DIFF
--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -66,6 +66,9 @@ jobs:
           component_args=()
           echo "Snap components:"
           for comp_file in *.comp; do
+              # When no .comp files exist, bash leaves the glob pattern unexpanded (*.comp). Check if $comp_file exists.
+              [ -f "$comp_file" ] || continue
+
               comp_size=$(du -h "$comp_file" | cut -f1)
 
               # Component file name patterns:


### PR DESCRIPTION
If this workflow is used to build and upload a snap that does not contain components, the upload fails. See: https://github.com/canonical/open-webui-snap/actions/runs/22432099621/job/64953027890

This properly checks for the existence of components before trying to upload them. Example run: https://github.com/canonical/open-webui-snap/actions/runs/22438671140