### PR TITLE
Specify ref to avoid simulated merge commits

### DIFF
--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -44,6 +44,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          # Prevent usage of simulated merge commit of PR
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           lfs: true
           submodules: true
 


### PR DESCRIPTION
Resolves: https://github.com/canonical/inference-snaps/issues/260

See full description in issue ^

By default `actions/checkout` will pull a simulated merge commit of the PR on the target branch. This simulated merge will contain changes from both the PR as well as the target branch. This specific commit (hash) does not exist in the repo history, as it is a simulated merge only for this session.

To prevent usage of the simulated merge commit, we specify the ref of the head of the PR's branch, and fall back to the sha of the current commit to cover non-PR triggered runs.

Tested in: https://github.com/canonical/gemma3-snap/pull/103