### PR TITLE
Add repository setup script

### DIFF
--- a/data/repository/default_ruleset.json
+++ b/data/repository/default_ruleset.json
@@ -1,0 +1,45 @@
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "~DEFAULT_BRANCH"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_signatures"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": [
+          "squash"
+        ]
+      }
+    }
+  ]
+}

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 # Configuration variables
+RULESET_FILE=${RULESET_FILE:-"data/repository/default_ruleset.json"}
 REPOSITORY_OWNER="${REPOSITORY_OWNER:-canonical}"
 TEAM_NAME="${TEAM_NAME:-industrial}"
 CLI_TOOL="${CLI_TOOL:-gh-beta}"
@@ -76,7 +77,7 @@ Optional arguments:
   --help                    Show this help message and exit.
 
 Environment overrides:
-  REPOSITORY_OWNER, TEAM_NAME, CLI_TOOL, DRY_RUN
+  REPOSITORY_OWNER, TEAM_NAME, CLI_TOOL, DRY_RUN, RULESET_FILE
 
 Examples:
   $0 --model model5 --snap model5 --visibility public
@@ -189,7 +190,7 @@ add_team_permissions() {
 add_branch_rules() {
     echo "Creating branch ruleset for the default branch..."
 
-    gh_api_json POST "/repos/${REPOSITORY_OWNER}/${repo_name}/rulesets" "$(cat data/repository/default_ruleset.json)"
+    gh_api_json POST "/repos/${REPOSITORY_OWNER}/${repo_name}/rulesets" "$(cat "$RULESET_FILE")"
 }
 
 add_website_and_description() {
@@ -225,6 +226,12 @@ main() {
     # Args parsing and validation
     parse_args "$@"
     validate_inputs
+
+    # Ensure required files exist
+    if [[ ! -f "$RULESET_FILE" ]]; then
+        fail "Ruleset file '$RULESET_FILE' not found."
+    fi
+
 
     if [[ "$dry_run" == true ]]; then
         echo "Dry run mode: no changes will be made to GitHub."

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -122,6 +122,32 @@ validate_snap_name() {
     fi
 }
 
+validate_owner_name() {
+    local value="$1"
+
+    # GitHub user/org names are 1-39 chars, alphanumeric or single hyphens, and cannot start/end with '-'.
+    if [[ ! "$value" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+        fail "invalid owner '$value'. Expected 1-39 characters using letters, digits, and single dashes; cannot start or end with a dash."
+    fi
+
+    if [[ "$value" == *--* ]]; then
+        fail "invalid owner '$value'. Consecutive dashes are not allowed in GitHub owner names."
+    fi
+}
+
+validate_repo_name() {
+    local value="$1"
+
+    # Repository names cannot contain spaces or '/'. Keep this strict to avoid malformed API calls.
+    if [[ ! "$value" =~ ^[A-Za-z0-9._-]+$ ]]; then
+        fail "invalid repo name '$value'. Expected letters, digits, dot, underscore, or dash only."
+    fi
+
+    if [[ "$value" == *.git ]]; then
+        fail "invalid repo name '$value'. Do not include the '.git' suffix."
+    fi
+}
+
 parse_args() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -204,7 +230,14 @@ validate_team_slug() {
 validate_inputs() {
     [[ -n "$model_name" ]] || fail "--model is required and cannot be empty"
     [[ -n "$snap_name" ]] || fail "--snap is required and cannot be empty"
+    validate_snap_name "$snap_name"
+
     [[ -n "$repo_owner" ]] || fail "--owner is required and cannot be empty"
+    validate_owner_name "$repo_owner"
+
+    if [[ -n "$repo_name" ]]; then
+        validate_repo_name "$repo_name"
+    fi
 
     if [[ "$modify_existing_repo" == false ]]; then
         # Only validate visibility if we're creating a new repo.
@@ -217,8 +250,6 @@ validate_inputs() {
                 ;;
         esac
     fi
-
-    validate_snap_name "$snap_name"
 
     # Ensure required files exist
     if [[ -n "$ruleset_file" && ! -f "$ruleset_file" ]]; then

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -8,6 +8,7 @@ REPOSITORY_OWNER="${REPOSITORY_OWNER:-canonical}"
 TEAM_NAME="${TEAM_NAME:-industrial}"
 CLI_TOOL="${CLI_TOOL:-gh-beta}"
 
+# Global variables
 model_name=""
 snap_name=""
 repo_name=""
@@ -233,18 +234,18 @@ main() {
     fi
 
 
-    if [[ "$dry_run" == true ]]; then
-        echo "Dry run mode: no changes will be made to GitHub."
-    fi
-
     # Check if GitHub CLI is installed
     if ! command -v "$CLI_TOOL" &> /dev/null; then
         fail "GitHub CLI ($CLI_TOOL) is required, but not installed. You can install it from https://cli.github.com/."
     fi
 
-    # Check if GitHub CLI is authenticated (only if not in dry-run mode)
-    if [[ "$dry_run" != true ]] && ! gh_cmd auth status >/dev/null 2>&1; then
-        fail "GitHub CLI is not authenticated. Run 'gh auth login' first."
+    if [[ "$dry_run" == true ]]; then
+        echo "Dry run mode: no changes will be made to GitHub."
+    else 
+        # Check if GitHub CLI is authenticated
+        if ! gh_cmd auth status >/dev/null 2>&1; then
+            fail "GitHub CLI is not authenticated. Run 'gh auth login' first."
+        fi
     fi
 
     # Summary and confirmation

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -13,6 +13,7 @@ repo_owner=""
 team_slug=""
 visibility=""
 ruleset_file=""
+modify_existing_repo=false
 dry_run=false
 assume_yes=false
 debug=false
@@ -86,6 +87,8 @@ Optional arguments:
   --add-team <team_slug>    Add a team with direct access (admin permissions) to the repository.
   --repo <repo_name>        Repository name. Defaults to <snap_name>-snap.
   --add-ruleset <file>      Add branch rules from a ruleset file.
+  --modify-existing-repo    Skip repository creation and apply settings to an existing 
+                            repository. If used, --visibility is ignored.
   --assume-yes              Skip confirmation prompts.
   --debug                   Show full GitHub API responses.
   --dry-run                 Print GitHub commands without executing them.
@@ -157,6 +160,10 @@ parse_args() {
                 visibility="$2"
                 shift 2
                 ;;
+            --modify-existing-repo)
+                modify_existing_repo=true
+                shift
+                ;;
             --assume-yes)
                 assume_yes=true
                 shift
@@ -197,16 +204,19 @@ validate_team_slug() {
 validate_inputs() {
     [[ -n "$model_name" ]] || fail "--model is required and cannot be empty"
     [[ -n "$snap_name" ]] || fail "--snap is required and cannot be empty"
-    [[ -n "$visibility" ]] || fail "--visibility is required and cannot be empty"
     [[ -n "$repo_owner" ]] || fail "--owner is required and cannot be empty"
 
-    case "$visibility" in
-        public|private|internal)
-            ;;
-        *)
-            fail "invalid visibility '$visibility'. Expected 'public', 'private', or 'internal'."
-            ;;
-    esac
+    if [[ "$modify_existing_repo" == false ]]; then
+        # Only validate visibility if we're creating a new repo.
+        [[ -n "$visibility" ]] || fail "--visibility is required and cannot be empty"
+        case "$visibility" in
+            public|private|internal)
+                ;;
+            *)
+                fail "invalid visibility '$visibility'. Expected 'public', 'private', or 'internal'."
+                ;;
+        esac
+    fi
 
     validate_snap_name "$snap_name"
 
@@ -216,18 +226,21 @@ validate_inputs() {
     fi
 }
 
-create_repo() {
-    echo "Creating repository ${repo_owner}/${repo_name}..."
-    
-    local repo_description="Local inference with ${model_name}"
-    local repo_homepage="https://snapcraft.io/${snap_name}"
+ensure_repo_exists() {
+    if [[ "$modify_existing_repo" == true ]]; then
+        # Validate repo existence
+        echo "Verifying repository ${repo_owner}/${repo_name} exists for modification..."
+        if ! "$CLI_TOOL" repo view "${repo_owner}/${repo_name}" >/dev/null 2>&1; then
+            fail "Repository '${repo_owner}/${repo_name}' not found or inaccessible. Cannot modify non-existing repository."
+        fi
+    else
+        # Create repo
+        echo "Creating repository ${repo_owner}/${repo_name}..."
+        gh_cmd repo create "${repo_owner}/${repo_name}" "--${visibility}"
+    fi
+}
 
-    # Create repo
-    gh_cmd repo create "${repo_owner}/${repo_name}" \
-        "--${visibility}" \
-        --description "$repo_description" \
-        --homepage "$repo_homepage"
-
+setup_repository_settings() {
     # Add topic
     echo "Setting repository topic..."
     gh_api_json PUT "/repos/${repo_owner}/${repo_name}/topics" "$(cat <<EOF
@@ -238,10 +251,13 @@ create_repo() {
 }
 EOF
 )"
-    # Customize settings after creation, since some settings (e.g. squash merge) can't be set during creation
+
+    # Customize settings
     echo "Applying repository-level settings after creation..."
     gh_api_json PATCH "/repos/${repo_owner}/${repo_name}" "$(cat <<EOF
 {
+    "description": "Local inference with ${model_name}",
+    "homepage": "https://snapcraft.io/${snap_name}",
     "has_wiki": false,
     "has_issues": false,
     "has_projects": false,
@@ -317,16 +333,21 @@ main() {
 
     # Summary
     echo ""
-    echo "Repository will be created with the following settings:"
+    echo "Repository will be set-up with the following values:"
     echo "  - Model name: $model_name"
     echo "  - Repository: $repo_owner/$repo_name"
     echo "  - Snap name: $snap_name"
-    echo "  - Repository visibility: $visibility"
+    echo "  - Repository visibility: $([[ "$modify_existing_repo" == true ]] && echo "unchanged" || echo "$visibility")"
     echo "  - Team with admin access: ${team_slug:-none}"
     echo "  - Branch ruleset file: ${ruleset_file:-none}"
     echo ""
-    echo "Once created, the repository will be available at https://www.github.com/$repo_owner/$repo_name"
+    echo "The repository will be available at https://www.github.com/$repo_owner/$repo_name"
     echo ""
+
+    if [[ "$modify_existing_repo" == true ]]; then
+        echo "WARNING: --modify-existing-repo is enabled, this script will change settings to an existing repository. Repository visibility will be left unchanged."
+        echo ""
+    fi
 
     # Confirmation
     if [[ "$assume_yes" == true ]]; then
@@ -337,7 +358,8 @@ main() {
     fi
 
     # Execution
-    create_repo
+    ensure_repo_exists
+    setup_repository_settings
     add_workflow_trigger_labels
     add_team_permissions
     add_branch_rules

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -208,7 +208,7 @@ main() {
         exit 1
     fi
 
-    if [[ "$DRY_RUN" == false ]] && ! "$CLI_TOOL" auth status >/dev/null 2>&1; then
+    if [[ "$DRY_RUN" == false ]] && ! gh_cmd auth status >/dev/null 2>&1; then
         echo "Error: GitHub CLI is not authenticated. Run 'gh auth login' first."
         exit 1
     fi

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -66,7 +66,7 @@ Create and configure a new inference snap repository under ${REPOSITORY_OWNER}.
 Required arguments:
   --model <model_name>      Model name used in the repository description.
   --snap <snap_name>        Snap store name. Must be lowercase and contain only
-                         letters, digits, and single dashes.
+                            letters, digits, and single dashes.
   --visibility <visibility> Repository visibility: public, private, or internal.
 
 Optional arguments:
@@ -220,7 +220,9 @@ add_workflow_trigger_labels() {
     gh_cmd label create --force trigger-build --repo "${REPOSITORY_OWNER}/${repo_name}" --color 78AF54 --description "Trigger build pipeline and publish snap"
     gh_cmd label create --force trigger-tests --repo "${REPOSITORY_OWNER}/${repo_name}" --color 9A1F77 --description "Trigger test pipeline on last build, if not present triggers also build"
 }
+
 main() {
+    # Args parsing and validation
     parse_args "$@"
     validate_inputs
 
@@ -233,6 +235,7 @@ main() {
         fail "GitHub CLI ($CLI_TOOL) is required, but not installed. You can install it from https://cli.github.com/."
     fi
 
+    # Check if GitHub CLI is authenticated (only if not in dry-run mode)
     if [[ "$dry_run" != true ]] && ! gh_cmd auth status >/dev/null 2>&1; then
         fail "GitHub CLI is not authenticated. Run 'gh auth login' first."
     fi
@@ -243,13 +246,14 @@ main() {
     echo "  - Model name: $model_name"
     echo "  - Repository name: $repo_name"
     echo "  - Snap name: $snap_name"
-    echo "  - Repository visibility: $([[ "$private" == true ]] && echo "private" || echo "public")"
+    echo "  - Repository visibility: $visibility"
     echo ""
     echo "Once created, the repository will be available at https://www.github.com/$REPOSITORY_OWNER/$repo_name"
     echo ""
 
+    # Confirmation
     if [[ "$assume_yes" == true ]]; then
-        echo "Assuming yes: continuing without prompts."
+        echo "Assuming yes: skipping confirmation prompts."
     elif ! ask_yes_no "> Do you want to proceed with these settings?"; then
         echo "Aborting."
         exit 0

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -5,8 +5,14 @@ set -euo pipefail
 # Configuration variables
 REPOSITORY_OWNER="${REPOSITORY_OWNER:-canonical}"
 TEAM_NAME="${TEAM_NAME:-industrial}"
-CLI_TOOL="${CLI_TOOL:-gh}"
-DRY_RUN="${DRY_RUN:-false}"
+CLI_TOOL="${CLI_TOOL:-gh-beta}"
+
+model_name=""
+snap_name=""
+repo_name=""
+private=false
+dry_run=false
+assume_yes=false
 
 print_cmd() {
     printf "+ "
@@ -15,7 +21,7 @@ print_cmd() {
 }
 
 gh_cmd() {
-    if [[ "$DRY_RUN" == true ]]; then
+    if [[ "$dry_run" == true ]]; then
         print_cmd "$CLI_TOOL" "$@"
     else
         "$CLI_TOOL" "$@"
@@ -27,7 +33,7 @@ gh_api_json() {
     local endpoint="$2"
     local payload="$3"
 
-    if [[ "$DRY_RUN" == true ]]; then
+    if [[ "$dry_run" == true ]]; then
         print_cmd "$CLI_TOOL" api --method "$method" "$endpoint" --input -
         printf "%s\n" "$payload"
     else
@@ -36,6 +42,10 @@ gh_api_json() {
 }
 
 ask_yes_no() {
+    if [[ "$assume_yes" == true ]]; then
+        return 0
+    fi
+
     read -p "$1 (y/N): " response
     case "$response" in
         [yY][eE][sS]|[yY])
@@ -45,6 +55,98 @@ ask_yes_no() {
             return 1
             ;;
     esac
+}
+
+print_help() {
+    cat <<EOF
+Usage: $0 --model <model_name> --snap <snap_name> [options]
+
+Create and configure a new inference snap repository under ${REPOSITORY_OWNER}.
+
+Required arguments:
+  --model <model_name>   Model name used in the repository description.
+  --snap <snap_name>     Snap store name. Must be lowercase and contain only
+                         letters, digits, and single dashes.
+
+Optional arguments:
+  --repo <repo_name>     Repository name. Defaults to <snap_name>-snap.
+  --private              Create the repository as private. Defaults to public.
+  --assume-yes           Skip confirmation prompts.
+  --dry-run              Print GitHub commands without executing them.
+  --help                 Show this help message and exit.
+
+Environment overrides:
+  REPOSITORY_OWNER, TEAM_NAME, CLI_TOOL, DRY_RUN
+
+Examples:
+  $0 --model model5 --snap model5
+  $0 --model "Model 3.5 Flash" --snap "model3-5-flash" --repo custom-repo --private --assume-yes
+EOF
+}
+
+fail() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+validate_snap_name() {
+    local value="$1"
+
+    if [[ ! "$value" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+        fail "invalid snap name '$value'. Expected lowercase letters, digits, and single dashes only."
+    fi
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --model)
+                [[ $# -ge 2 ]] || fail "--model requires a value"
+                model_name="$2"
+                shift 2
+                ;;
+            --snap)
+                [[ $# -ge 2 ]] || fail "--snap requires a value"
+                snap_name="$2"
+                shift 2
+                ;;
+            --repo)
+                [[ $# -ge 2 ]] || fail "--repo requires a value"
+                repo_name="$2"
+                shift 2
+                ;;
+            --private)
+                private=true
+                shift
+                ;;
+            --assume-yes)
+                assume_yes=true
+                shift
+                ;;
+            --dry-run)
+                dry_run=true
+                shift
+                ;;
+            --help)
+                print_help
+                exit 0
+                ;;
+            *)
+                fail "unknown argument '$1'"
+                ;;
+        esac
+    done
+}
+
+validate_inputs() {
+    [[ -n "$model_name" ]] || fail "--model is required and cannot be empty"
+    [[ -n "$snap_name" ]] || fail "--snap is required and cannot be empty"
+
+    validate_snap_name "$snap_name"
+
+    if [[ -z "$repo_name" ]]; then
+        repo_name="${snap_name}-snap"
+    fi
 }
 
 create_repo() {
@@ -113,80 +215,21 @@ add_workflow_trigger_labels() {
     gh_cmd label create --force trigger-build --repo "${REPOSITORY_OWNER}/${repo_name}" --color 78AF54 --description "Trigger build pipeline and publish snap"
     gh_cmd label create --force trigger-tests --repo "${REPOSITORY_OWNER}/${repo_name}" --color 9A1F77 --description "Trigger test pipeline on last build, if not present triggers also build"
 }
-
-print_help() {
-    echo "Usage: $0"
-    echo ""
-    echo "This script will guide you through the creation and setup of a new repository for an inference snap."
-    echo "It will ask you for the necessary information and then create the repository with the appropriate settings and permissions."
-    echo ""
-    echo "Configuration defaults can be overridden with environment variables: REPOSITORY_OWNER, TEAM_NAME, CLI_TOOL, DRY_RUN."
-    echo ""
-    echo "You can use '--dry-run' option to see what actions would be taken without actually performing them."
-    echo ""
-}
-
 main() {
-    # Read parameters (--help or --dry-run)
-    for arg in "$@"; do
-        case "$arg" in
-            --dry-run)
-                DRY_RUN=true
-                ;;
-            --help)
-                print_help
-                exit 0
-                ;;
-            *)
-                echo "Error: unknown argument '$arg'"
-                print_help
-                exit 1
-                ;;
-        esac
-    done
+    parse_args "$@"
+    validate_inputs
 
-    if [[ "$DRY_RUN" == true ]]; then
+    if [[ "$dry_run" == true ]]; then
         echo "Dry run mode: no changes will be made to GitHub."
     fi
 
-    echo "This script will guide you into the creation and setup of a new repository for an inference snap."
-    echo ""
-
     # Check if GitHub CLI is installed
     if ! command -v "$CLI_TOOL" &> /dev/null; then
-        echo "Error: GitHub CLI ($CLI_TOOL) is required, but not installed. You can install it from https://cli.github.com/."
-        exit 1
+        fail "GitHub CLI ($CLI_TOOL) is required, but not installed. You can install it from https://cli.github.com/."
     fi
 
-    if [[ "$DRY_RUN" == false ]] && ! gh_cmd auth status >/dev/null 2>&1; then
-        echo "Error: GitHub CLI is not authenticated. Run 'gh auth login' first."
-        exit 1
-    fi
-
-    # Data input: model name
-    read -p "> Enter the AI model name (e.g. 'model5'): " model_name
-    if [[ -z "$model_name" ]]; then
-        echo "Error: model name cannot be empty."
-        exit 1
-    fi
-
-    # Data input: snap store name
-    read -p "> Enter the snap store name (default: '${model_name}'): " snap_name
-    if [[ -z "$snap_name" ]]; then
-        snap_name="$model_name"
-    fi
-
-    # Data input: repository name
-    read -p "> Enter a name for the new repository (default: '${snap_name}-snap'): " repo_name
-    if [[ -z "$repo_name" ]]; then
-        repo_name="${snap_name}-snap"
-    fi
-
-    # Data input: private or public repository
-    if ask_yes_no "> Should the repository be private?"; then
-        private=true
-    else
-        private=false
+    if [[ "$dry_run" != true ]] && ! gh_cmd auth status >/dev/null 2>&1; then
+        fail "GitHub CLI is not authenticated. Run 'gh auth login' first."
     fi
 
     # Summary and confirmation
@@ -200,7 +243,9 @@ main() {
     echo "Once created, the repository will be available at https://www.github.com/$REPOSITORY_OWNER/$repo_name"
     echo ""
 
-    if ! ask_yes_no "> Do you want to proceed with these settings?"; then
+    if [[ "$assume_yes" == true ]]; then
+        echo "Assuming yes: continuing without prompts."
+    elif ! ask_yes_no "> Do you want to proceed with these settings?"; then
         echo "Aborting."
         exit 0
     fi

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+set -e
+
+# Configuration variables
+REPOSITORY_OWNER="canonical"
+TEAM_NAME="industrial"
+CLI_TOOL="gh_disabled" # GitHub CLI tool # TODO: change to gh when ready, for now we disable it to avoid accidental execution while the script is being developed
+
+ask_yes_no() {
+    read -p "$1 (y/N): " response
+    case "$response" in
+        [yY][eE][sS]|[yY])
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+create_repo() {
+#   - Create repository (public or private, as desired)
+#   - Disable Wiki, Issues and Projects
+#   - Disallow merge commits and rebase merges, but allow squash merges
+#   - Enable "Always suggest updating pull request branches "
+#   - Enable "Allow auto-merge"
+#   - Enable "Automatically delete head branches"
+#   - Enable main branch protection rules (require pull request reviews before merging, require status checks to pass before merging, require branches to be up to date before merging)
+}
+
+add_team_permissions() {
+#  - Add "@canonical/industrial" team with direct access (admin permissions)
+}
+
+add_branch_rules() {
+#   - Create ruleset for main branch:
+#       - Bypass list: Repository Admin
+#       - Target branch: default (main)
+#       - Only restrict deletions
+#       - Require signed commits
+#       - Require a pull request before merging
+#       - Block force pushes
+}
+
+add_website_and_description() {
+#   - Add description: "Local inference with ${model_name}"
+#   - Add website: "https://snapcraft.io/${model_name}"
+#   - Add Topic: "inference-snap"
+}
+
+add_workflow_trigger_labels() {
+#   - Add label "trigger-build" with description "Trigger build pipeline and publish snap"
+#   - Add label "trigger-tests" with description "Trigger test pipeline on last build, if not present triggers also build"
+}
+
+print_help() {
+    echo "Usage: $0"
+    echo ""
+    echo "This script will guide you through the creation and setup of a new repository for an inference snap."
+    echo "It will ask you for the necessary information and then create the repository with the appropriate settings and permissions."
+    echo ""
+    echo "You can use '--dry-run' option to see what actions would be taken without actually performing them."
+    echo ""
+}
+
+main() {
+    # Read parameters (--help or --dry-run)
+    if [[ "$1" == "--dry-run" ]]; then
+        echo "Dry run mode: no changes will be made to GitHub."
+        CLI_TOOL="echo $CLI_TOOL (dry run)"
+    elif [[ "$1" == "--help" ]]; then
+        print_help
+        exit 0
+    fi
+
+
+
+    echo "This script will guide you into the creation and setup of a new repository for an inference snap."
+    echo ""
+
+    # Check if GitHub CLI is installed
+    if ! command -v $CLI_TOOL &> /dev/null; then
+        echo "Error: GitHub CLI ($CLI_TOOL) is required, but not installed. You can install it from https://cli.github.com/."
+        exit 1
+    fi
+
+    # Data input: model name
+    read -p "> Enter the AI model name (e.g. 'model5'): " model_name
+    if [[ -z "$model_name" ]]; then
+        echo "Error: model name cannot be empty."
+        exit 1
+    fi
+
+    # Data input: snap store name
+    read -p "> Enter the snap store name (default: '${model_name}'): " snap_name
+    if [[ -z "$snap_name" ]]; then
+        snap_name="$model_name"
+    fi
+
+    # Data input: repository name
+    read -p "> Enter a name for the new repository (default: '${model_name}-snap'): " repo_name
+    if [[ -z "$repo_name" ]]; then
+        repo_name="${model_name}-snap"
+    fi
+
+    # Data input: private or public repository
+    if ask_yes_no "> Should the repository be private?"; then
+        private=true
+    else
+        private=false
+    fi
+
+    # Summary and confirmation
+    echo ""
+    echo "Repository will be created with the following settings:"
+    echo "  - Model name: $model_name"
+    echo "  - Repository name: $repo_name"
+    echo "  - Snap name: $snap_name"
+    echo "  - Repository visibility: $([[ "$private" == true ]] && echo "Private" || echo "Public")"
+    echo ""
+
+    if ! ask_yes_no "> Do you want to proceed with these settings?"; then
+        echo "Aborting."
+        exit 0
+    fi
+
+    # Execution
+    create_repo
+    add_team_permissions
+    add_branch_rules
+    add_website_and_description
+    add_workflow_trigger_labels
+
+    # Completion message
+    echo "Repository setup complete!"
+    echo "Access it here: https://www.github.com/$REPOSITORY_OWNER/$repo_name"
+}
+
+main

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -238,6 +238,8 @@ EOF
 }
 
 add_team_permissions() {
+    [[ -n "$team_slug" ]] || return 0
+
     # Add REPOSITORY_OWNER/team_slug (e.g. "@canonical/industrial") team with direct access (admin permissions)
     # Doing this with "--team" during repo creation isn't reliable, see here: https://github.com/cli/cli/discussions/6906
 
@@ -309,9 +311,7 @@ main() {
     # Execution
     create_repo
     add_workflow_trigger_labels
-    if [[ -n "$team_slug" ]]; then
-        add_team_permissions
-    fi
+    add_team_permissions
     add_branch_rules
 
     # Completion message

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -157,13 +157,13 @@ EOF
 
 add_website_and_description() {
 #   - Add description: "Local inference with ${model_name}"
-#   - Add website: "https://snapcraft.io/${model_name}"
+#   - Add website: "https://snapcraft.io/${snap_name}"
 #   - Add Topic: "inference-snap"
     echo "Setting repository description, website, and topic..."
     gh_api_json PATCH "/repos/${REPOSITORY_OWNER}/${repo_name}" "$(cat <<EOF
 {
     "description": "Local inference with ${model_name}",
-    "homepage": "https://snapcraft.io/${model_name}"
+    "homepage": "https://snapcraft.io/${snap_name}"
 }
 EOF
 )"

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -144,14 +144,6 @@ add_branch_rules() {
                     "squash"
                 ]
             }
-        },
-        {
-            "type": "required_status_checks",
-            "parameters": {
-                "do_not_enforce_on_create": false,
-                "required_status_checks": [],
-                "strict_required_status_checks_policy": true
-            }
         }
     ]
 }

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -247,6 +247,8 @@ main() {
     echo "  - Snap name: $snap_name"
     echo "  - Repository visibility: $([[ "$private" == true ]] && echo "private" || echo "public")"
     echo ""
+    echo "Once created, the repository will be available at https://www.github.com/$REPOSITORY_OWNER/$repo_name"
+    echo ""
 
     if ! ask_yes_no "> Do you want to proceed with these settings?"; then
         echo "Aborting."

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -15,6 +15,7 @@ repo_name=""
 visibility=""
 dry_run=false
 assume_yes=false
+debug=false
 
 print_cmd() {
     printf "+ "
@@ -39,7 +40,12 @@ gh_api_json() {
         print_cmd "$CLI_TOOL" api --method "$method" "$endpoint" --input -
         printf "%s\n" "$payload"
     else
-        printf "%s\n" "$payload" | "$CLI_TOOL" api --method "$method" "$endpoint" --input -
+        if [[ "$debug" == true ]]; then
+            printf "%s\n" "$payload" | "$CLI_TOOL" api --method "$method" "$endpoint" --input -
+        else
+            # Response body is not needed; suppress it to avoid pager/full-screen output.
+            printf "%s\n" "$payload" | "$CLI_TOOL" api --method "$method" "$endpoint" --input - >/dev/null
+        fi
     fi
 }
 
@@ -74,6 +80,7 @@ Required arguments:
 Optional arguments:
   --repo <repo_name>        Repository name. Defaults to <snap_name>-snap.
   --assume-yes              Skip confirmation prompts.
+  --debug                   Show full GitHub API responses.
   --dry-run                 Print GitHub commands without executing them.
   --help                    Show this help message and exit.
 
@@ -124,6 +131,10 @@ parse_args() {
                 ;;
             --assume-yes)
                 assume_yes=true
+                shift
+                ;;
+            --debug)
+                debug=true
                 shift
                 ;;
             --dry-run)

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -175,8 +175,8 @@ validate_inputs() {
 create_repo() {
     echo "Creating repository ${REPOSITORY_OWNER}/${repo_name}..."
     
-    repo_description="Local inference with ${model_name}"
-    repo_homepage="https://snapcraft.io/${snap_name}"
+    local repo_description="Local inference with ${model_name}"
+    local repo_homepage="https://snapcraft.io/${snap_name}"
 
     # Create repo
     gh_cmd repo create "${REPOSITORY_OWNER}/${repo_name}" \
@@ -244,7 +244,6 @@ main() {
     if [[ ! -f "$RULESET_FILE" ]]; then
         fail "Ruleset file '$RULESET_FILE' not found."
     fi
-
 
     # Check if GitHub CLI is installed
     if ! command -v "$CLI_TOOL" &> /dev/null; then

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -163,8 +163,27 @@ validate_inputs() {
 
 create_repo() {
     echo "Creating repository ${REPOSITORY_OWNER}/${repo_name}..."
-    gh_cmd repo create "${REPOSITORY_OWNER}/${repo_name}" "--${visibility}"
+    
+    repo_description="Local inference with ${model_name}"
+    repo_homepage="https://snapcraft.io/${snap_name}"
 
+    # Create repo
+    gh_cmd repo create "${REPOSITORY_OWNER}/${repo_name}" \
+        "--${visibility}" \
+        --description "$repo_description" \
+        --homepage "$repo_homepage"
+
+    # Add topic
+    echo "Setting repository topic..."
+    gh_api_json PUT "/repos/${REPOSITORY_OWNER}/${repo_name}/topics" "$(cat <<EOF
+{
+    "names": [
+        "inference-snap"
+    ]
+}
+EOF
+)"
+    # Customize settings after creation, since some settings (e.g. squash merge) can't be set during creation
     echo "Applying repository-level settings after creation..."
     gh_api_json PATCH "/repos/${REPOSITORY_OWNER}/${repo_name}" "$(cat <<EOF
 {
@@ -184,36 +203,15 @@ EOF
 
 add_team_permissions() {
     # Add REPOSITORY_OWNER/TEAM_NAME (e.g. "@canonical/industrial") team with direct access (admin permissions)
+    # Doing this with "--team" during repo creation isn't reliable, see here: https://github.com/cli/cli/discussions/6906
+
     echo "Granting team permissions to @${REPOSITORY_OWNER}/${TEAM_NAME}..."
     gh_api_json PUT "/orgs/${REPOSITORY_OWNER}/teams/${TEAM_NAME}/repos/${REPOSITORY_OWNER}/${repo_name}" "{\"permission\": \"admin\"}"
 }
 
 add_branch_rules() {
     echo "Creating branch ruleset for the default branch..."
-
     gh_api_json POST "/repos/${REPOSITORY_OWNER}/${repo_name}/rulesets" "$(cat "$RULESET_FILE")"
-}
-
-add_website_and_description() {
-    # Add description and website
-    echo "Setting repository description, website, and topic..."
-    gh_api_json PATCH "/repos/${REPOSITORY_OWNER}/${repo_name}" "$(cat <<EOF
-{
-    "description": "Local inference with ${model_name}",
-    "homepage": "https://snapcraft.io/${snap_name}"
-}
-EOF
-)"
-
-    # Add topic
-    gh_api_json PUT "/repos/${REPOSITORY_OWNER}/${repo_name}/topics" "$(cat <<EOF
-{
-    "names": [
-        "inference-snap"
-    ]
-}
-EOF
-)"
 }
 
 add_workflow_trigger_labels() {
@@ -271,7 +269,6 @@ main() {
     create_repo
     add_team_permissions
     add_branch_rules
-    add_website_and_description
     add_workflow_trigger_labels
 
     # Completion message

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -280,9 +280,9 @@ main() {
 
     # Execution
     create_repo
+    add_workflow_trigger_labels
     add_team_permissions
     add_branch_rules
-    add_workflow_trigger_labels
 
     # Completion message
     echo "Repository setup complete!"

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 # Configuration variables
-RULESET_FILE=${RULESET_FILE:-"data/repository/default_ruleset.json"}
 CLI_TOOL="${CLI_TOOL:-gh}"
 
 # Global variables
@@ -13,6 +12,7 @@ repo_name=""
 repo_owner=""
 team_slug=""
 visibility=""
+ruleset_file=""
 dry_run=false
 assume_yes=false
 debug=false
@@ -85,17 +85,24 @@ Required arguments:
 Optional arguments:
   --add-team <team_slug>    Add a team with direct access (admin permissions) to the repository.
   --repo <repo_name>        Repository name. Defaults to <snap_name>-snap.
+  --add-ruleset <file>      Add branch rules from a ruleset file.
   --assume-yes              Skip confirmation prompts.
   --debug                   Show full GitHub API responses.
   --dry-run                 Print GitHub commands without executing them.
   --help                    Show this help message and exit.
 
 Environment overrides:
-  CLI_TOOL, RULESET_FILE
+  CLI_TOOL                  Command-line tool for GitHub interactions (default: gh).
 
 Examples:
   $0 --model model5 --snap model5 --visibility public --owner canonical
-  $0 --model "Model 3.5 Flash" --snap "model3-5-flash" --owner canonical --repo custom-repo --visibility private --assume-yes
+  $0 --model "Model 3.5 Flash" \
+    --snap "model3-5-flash" \
+    --owner canonical \
+    --repo custom-repo \
+    --visibility private \
+    --add-ruleset data/repository/default_ruleset.json \
+    --assume-yes
 EOF
 }
 
@@ -138,6 +145,11 @@ parse_args() {
             --add-team)
                 [[ $# -ge 2 ]] || fail "--add-team requires a value"
                 team_slug="$2"
+                shift 2
+                ;;
+            --add-ruleset)
+                [[ $# -ge 2 ]] || fail "--add-ruleset requires a value"
+                ruleset_file="$2"
                 shift 2
                 ;;
             --visibility)
@@ -199,8 +211,8 @@ validate_inputs() {
     validate_snap_name "$snap_name"
 
     # Ensure required files exist
-    if [[ ! -f "$RULESET_FILE" ]]; then
-        fail "Ruleset file '$RULESET_FILE' not found."
+    if [[ -n "$ruleset_file" && ! -f "$ruleset_file" ]]; then
+        fail "Ruleset file '$ruleset_file' not found."
     fi
 }
 
@@ -245,7 +257,10 @@ EOF
 }
 
 add_team_permissions() {
-    [[ -n "$team_slug" ]] || return 0
+    if [[ -z "$team_slug" ]]; then
+        echo "Skipping team permissions setup: no team specified."
+        return 0
+    fi
 
     # Add REPOSITORY_OWNER/team_slug (e.g. "@canonical/industrial") team with direct access (admin permissions)
     # Doing this with "--team" during repo creation isn't reliable, see here: https://github.com/cli/cli/discussions/6906
@@ -258,8 +273,13 @@ add_team_permissions() {
 }
 
 add_branch_rules() {
+    if [[ -z "$ruleset_file" ]]; then
+        echo "Skipping branch rules setup: no ruleset file provided."
+        return 0
+    fi
+
     echo "Creating branch ruleset for the default branch..."
-    gh_api_json POST "/repos/${repo_owner}/${repo_name}/rulesets" "$(cat "$RULESET_FILE")"
+    gh_api_json POST "/repos/${repo_owner}/${repo_name}/rulesets" "$(cat "$ruleset_file")"
 }
 
 add_workflow_trigger_labels() {
@@ -303,6 +323,7 @@ main() {
     echo "  - Snap name: $snap_name"
     echo "  - Repository visibility: $visibility"
     echo "  - Team with admin access: ${team_slug:-none}"
+    echo "  - Branch ruleset file: ${ruleset_file:-none}"
     echo ""
     echo "Once created, the repository will be available at https://www.github.com/$repo_owner/$repo_name"
     echo ""

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -3,10 +3,10 @@
 set -euo pipefail
 
 # Configuration variables
-REPOSITORY_OWNER="canonical"
-TEAM_NAME="industrial"
-CLI_TOOL="gh"
-DRY_RUN=false
+REPOSITORY_OWNER="${REPOSITORY_OWNER:-canonical}"
+TEAM_NAME="${TEAM_NAME:-industrial}"
+CLI_TOOL="${CLI_TOOL:-gh}"
+DRY_RUN="${DRY_RUN:-false}"
 
 print_cmd() {
     printf "+ "
@@ -171,6 +171,8 @@ print_help() {
     echo ""
     echo "This script will guide you through the creation and setup of a new repository for an inference snap."
     echo "It will ask you for the necessary information and then create the repository with the appropriate settings and permissions."
+    echo ""
+    echo "Configuration defaults can be overridden with environment variables: REPOSITORY_OWNER, TEAM_NAME, CLI_TOOL, DRY_RUN."
     echo ""
     echo "You can use '--dry-run' option to see what actions would be taken without actually performing them."
     echo ""

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -261,7 +261,7 @@ ensure_repo_exists() {
     if [[ "$modify_existing_repo" == true ]]; then
         # Validate repo existence
         echo "Verifying repository ${repo_owner}/${repo_name} exists for modification..."
-        if ! "$CLI_TOOL" repo view "${repo_owner}/${repo_name}" >/dev/null 2>&1; then
+        if ! gh_cmd repo view "${repo_owner}/${repo_name}"; then
             fail "Repository '${repo_owner}/${repo_name}' not found or inaccessible. Cannot modify non-existing repository."
         fi
     else

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -216,6 +216,9 @@ add_team_permissions() {
     # Add REPOSITORY_OWNER/TEAM_SLUG (e.g. "@canonical/industrial") team with direct access (admin permissions)
     # Doing this with "--team" during repo creation isn't reliable, see here: https://github.com/cli/cli/discussions/6906
 
+    # API specification: https://docs.github.com/en/rest/teams/teams?apiVersion=2026-03-10#add-or-update-team-repository-permissions
+    # Permission levels: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permission-levels-for-repositories-owned-by-an-organization
+
     echo "Granting team permissions to @${REPOSITORY_OWNER}/${TEAM_SLUG}..."
     gh_api_json PUT "/orgs/${REPOSITORY_OWNER}/teams/${TEAM_SLUG}/repos/${REPOSITORY_OWNER}/${repo_name}" "{\"permission\": \"admin\"}"
 }

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -372,7 +372,7 @@ main() {
     echo "  - Team with admin access: ${team_slug:-none}"
     echo "  - Branch ruleset file: ${ruleset_file:-none}"
     echo ""
-    echo "The repository will be available at https://www.github.com/$repo_owner/$repo_name"
+    echo "The repository will be available at https://github.com/$repo_owner/$repo_name"
     echo ""
 
     if [[ "$modify_existing_repo" == true ]]; then
@@ -397,7 +397,7 @@ main() {
 
     # Completion message
     echo "Repository setup complete!"
-    echo "Access it here: https://www.github.com/$repo_owner/$repo_name"
+    echo "Access it here: https://github.com/$repo_owner/$repo_name"
 }
 
 main "$@"

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -36,19 +36,19 @@ gh_api_json() {
     local endpoint="$2"
     local payload="$3"
     local response=""
-    local status=0
+    local exit_code=0
 
     if [[ "$dry_run" == true ]]; then
         print_cmd "$CLI_TOOL" api --method "$method" "$endpoint" --input -
         printf "%s\n" "$payload"
     else
         # Keep successful calls quiet, but print API output when a call fails.
-        response="$(printf "%s\n" "$payload" | "$CLI_TOOL" api --method "$method" "$endpoint" --input - 2>&1)" || status=$?
-        if [[ "$status" -ne 0 || "$debug" == true ]]; then
+        response="$(printf "%s\n" "$payload" | "$CLI_TOOL" api --method "$method" "$endpoint" --input - 2>&1)" || exit_code=$?
+        if [[ "$exit_code" -ne 0 || "$debug" == true ]]; then
             if [[ -n "$response" ]]; then
                 printf "%s\n" "$response" >&2
             fi
-            return "$status"
+            return "$exit_code"
         fi
     fi
 }
@@ -177,8 +177,9 @@ validate_inputs() {
 
     validate_snap_name "$snap_name"
 
-    if [[ -z "$repo_name" ]]; then
-        repo_name="${snap_name}-snap"
+    # Ensure required files exist
+    if [[ ! -f "$RULESET_FILE" ]]; then
+        fail "Ruleset file '$RULESET_FILE' not found."
     fi
 }
 
@@ -246,14 +247,14 @@ add_workflow_trigger_labels() {
 }
 
 main() {
-    # Args parsing and validation
     parse_args "$@"
-    validate_inputs
 
-    # Ensure required files exist
-    if [[ ! -f "$RULESET_FILE" ]]; then
-        fail "Ruleset file '$RULESET_FILE' not found."
+    # Infer repo name if not provided
+    if [[ -z "$repo_name" ]]; then
+        repo_name="${snap_name}-snap"
     fi
+
+    validate_inputs
 
     # Check if GitHub CLI is installed
     if ! command -v "$CLI_TOOL" &> /dev/null; then
@@ -269,7 +270,7 @@ main() {
         fi
     fi
 
-    # Summary and confirmation
+    # Summary
     echo ""
     echo "Repository will be created with the following settings:"
     echo "  - Model name: $model_name"

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Configuration variables
 RULESET_FILE=${RULESET_FILE:-"data/repository/default_ruleset.json"}
 REPOSITORY_OWNER="${REPOSITORY_OWNER:-canonical}"
-TEAM_NAME="${TEAM_NAME:-industrial}"
+TEAM_SLUG="${TEAM_SLUG:-industrial}"
 CLI_TOOL="${CLI_TOOL:-gh}"
 
 # Global variables
@@ -85,7 +85,7 @@ Optional arguments:
   --help                    Show this help message and exit.
 
 Environment overrides:
-  REPOSITORY_OWNER, TEAM_NAME, CLI_TOOL, RULESET_FILE
+  REPOSITORY_OWNER, TEAM_SLUG, CLI_TOOL, RULESET_FILE
 
 Examples:
   $0 --model model5 --snap model5 --visibility public
@@ -213,11 +213,11 @@ EOF
 }
 
 add_team_permissions() {
-    # Add REPOSITORY_OWNER/TEAM_NAME (e.g. "@canonical/industrial") team with direct access (admin permissions)
+    # Add REPOSITORY_OWNER/TEAM_SLUG (e.g. "@canonical/industrial") team with direct access (admin permissions)
     # Doing this with "--team" during repo creation isn't reliable, see here: https://github.com/cli/cli/discussions/6906
 
-    echo "Granting team permissions to @${REPOSITORY_OWNER}/${TEAM_NAME}..."
-    gh_api_json PUT "/orgs/${REPOSITORY_OWNER}/teams/${TEAM_NAME}/repos/${REPOSITORY_OWNER}/${repo_name}" "{\"permission\": \"admin\"}"
+    echo "Granting team permissions to @${REPOSITORY_OWNER}/${TEAM_SLUG}..."
+    gh_api_json PUT "/orgs/${REPOSITORY_OWNER}/teams/${TEAM_SLUG}/repos/${REPOSITORY_OWNER}/${repo_name}" "{\"permission\": \"admin\"}"
 }
 
 add_branch_rules() {

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -87,54 +87,7 @@ EOF
 add_branch_rules() {
     echo "Creating branch ruleset for the default branch..."
 
-    gh_api_json POST "/repos/${REPOSITORY_OWNER}/${repo_name}/rulesets" "$(cat <<EOF
-{
-    "name": "main-branch-protection",
-    "target": "branch",
-    "enforcement": "active",
-    "bypass_actors": [
-        {
-            "actor_id": 5,
-            "actor_type": "RepositoryRole",
-            "bypass_mode": "pull_request"
-        }
-    ],
-    "conditions": {
-        "ref_name": {
-            "include": [
-                "~DEFAULT_BRANCH"
-            ],
-            "exclude": []
-        }
-    },
-    "rules": [
-        {
-            "type": "deletion"
-        },
-        {
-            "type": "non_fast_forward"
-        },
-        {
-            "type": "required_signatures"
-        },
-        {
-            "type": "pull_request",
-            "parameters": {
-                "required_approving_review_count": 1,
-                "dismiss_stale_reviews_on_push": false,
-                "required_reviewers": [],
-                "require_code_owner_review": false,
-                "require_last_push_approval": false,
-                "required_review_thread_resolution": false,
-                "allowed_merge_methods": [
-                    "squash"
-                ]
-            }
-        }
-    ]
-}
-EOF
-)"
+    gh_api_json POST "/repos/${REPOSITORY_OWNER}/${repo_name}/rulesets" "$(cat data/repository/default_ruleset.json)"
 }
 
 add_website_and_description() {

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -319,7 +319,7 @@ main() {
     echo ""
     echo "Repository will be created with the following settings:"
     echo "  - Model name: $model_name"
-    echo "  - Repository name: $repo_name"
+    echo "  - Repository: $repo_owner/$repo_name"
     echo "  - Snap name: $snap_name"
     echo "  - Repository visibility: $visibility"
     echo "  - Team with admin access: ${team_slug:-none}"

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -54,7 +54,7 @@ ask_yes_no() {
         return 0
     fi
 
-    read -p "$1 (y/N): " response
+    read -r -p "$1 (y/N): " response
     case "$response" in
         [yY][eE][sS]|[yY])
             return 0

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 RULESET_FILE=${RULESET_FILE:-"data/repository/default_ruleset.json"}
 REPOSITORY_OWNER="${REPOSITORY_OWNER:-canonical}"
 TEAM_NAME="${TEAM_NAME:-industrial}"
-CLI_TOOL="${CLI_TOOL:-gh-beta}"
+CLI_TOOL="${CLI_TOOL:-gh}"
 
 # Global variables
 model_name=""

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -48,14 +48,6 @@ ask_yes_no() {
 }
 
 create_repo() {
-#   - Create repository (public or private, as desired)
-#   - Disable Wiki, Issues and Projects
-#   - Disallow merge commits and rebase merges, but allow squash merges
-#   - Enable "Always suggest updating pull request branches "
-#   - Enable "Allow auto-merge"
-#   - Enable "Automatically delete head branches"
-#   - Enable main branch protection rules (require pull request reviews before merging, require status checks to pass before merging, require branches to be up to date before merging)
-
     local visibility_flag="--public"
     if [[ "$private" == true ]]; then
         visibility_flag="--private"
@@ -64,7 +56,7 @@ create_repo() {
     echo "Creating repository ${REPOSITORY_OWNER}/${repo_name}..."
     gh_cmd repo create "${REPOSITORY_OWNER}/${repo_name}" "$visibility_flag"
 
-    # Apply repository-level settings after creation.
+    echo "Applying repository-level settings after creation..."
     gh_api_json PATCH "/repos/${REPOSITORY_OWNER}/${repo_name}" "$(cat <<EOF
 {
     "has_wiki": false,
@@ -82,7 +74,7 @@ EOF
 }
 
 add_team_permissions() {
-    #  - Add REPOSITORY_OWNER/TEAM_NAME (e.g. "@canonical/industrial") team with direct access (admin permissions)
+    # Add REPOSITORY_OWNER/TEAM_NAME (e.g. "@canonical/industrial") team with direct access (admin permissions)
     echo "Granting team permissions to @${REPOSITORY_OWNER}/${TEAM_NAME}..."
     gh_api_json PUT "/orgs/${REPOSITORY_OWNER}/teams/${TEAM_NAME}/repos/${REPOSITORY_OWNER}/${repo_name}" "$(cat <<EOF
 {
@@ -93,14 +85,8 @@ EOF
 }
 
 add_branch_rules() {
-#   - Create ruleset for main branch:
-#       - Bypass list: Repository Admin
-#       - Target branch: default (main)
-#       - Only restrict deletions
-#       - Require signed commits
-#       - Require a pull request before merging
-#       - Block force pushes
     echo "Creating branch ruleset for the default branch..."
+
     gh_api_json POST "/repos/${REPOSITORY_OWNER}/${repo_name}/rulesets" "$(cat <<EOF
 {
     "name": "main-branch-protection",
@@ -152,9 +138,7 @@ EOF
 }
 
 add_website_and_description() {
-#   - Add description: "Local inference with ${model_name}"
-#   - Add website: "https://snapcraft.io/${snap_name}"
-#   - Add Topic: "inference-snap"
+    # Add description and website
     echo "Setting repository description, website, and topic..."
     gh_api_json PATCH "/repos/${REPOSITORY_OWNER}/${repo_name}" "$(cat <<EOF
 {
@@ -164,6 +148,7 @@ add_website_and_description() {
 EOF
 )"
 
+    # Add topic
     gh_api_json PUT "/repos/${REPOSITORY_OWNER}/${repo_name}/topics" "$(cat <<EOF
 {
     "names": [
@@ -175,11 +160,10 @@ EOF
 }
 
 add_workflow_trigger_labels() {
-#   - Add label "trigger-build" with description "Trigger build pipeline and publish snap"
-#   - Add label "trigger-tests" with description "Trigger test pipeline on last build, if not present triggers also build"
     echo "Creating workflow trigger labels..."
-    gh_cmd label create trigger-build --repo "${REPOSITORY_OWNER}/${repo_name}" --color 78af54 --description "Trigger build pipeline and publish snap" --force
-    gh_cmd label create trigger-tests --repo "${REPOSITORY_OWNER}/${repo_name}" --color 9a1f77 --description "Trigger test pipeline on last build, if not present triggers also build" --force
+
+    gh_cmd label create trigger-build --repo "${REPOSITORY_OWNER}/${repo_name}" --color 78AF54 --description "Trigger build pipeline and publish snap" --force
+    gh_cmd label create trigger-tests --repo "${REPOSITORY_OWNER}/${repo_name}" --color 9A1F77 --description "Trigger test pipeline on last build, if not present triggers also build" --force
 }
 
 print_help() {

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -182,9 +182,9 @@ main() {
     fi
 
     # Data input: repository name
-    read -p "> Enter a name for the new repository (default: '${model_name}-snap'): " repo_name
+    read -p "> Enter a name for the new repository (default: '${snap_name}-snap'): " repo_name
     if [[ -z "$repo_name" ]]; then
-        repo_name="${model_name}-snap"
+        repo_name="${snap_name}-snap"
     fi
 
     # Data input: private or public repository

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -10,7 +10,7 @@ CLI_TOOL="${CLI_TOOL:-gh-beta}"
 model_name=""
 snap_name=""
 repo_name=""
-private=false
+visibility=""
 dry_run=false
 assume_yes=false
 
@@ -59,28 +59,28 @@ ask_yes_no() {
 
 print_help() {
     cat <<EOF
-Usage: $0 --model <model_name> --snap <snap_name> [options]
+Usage: $0 --model <model_name> --snap <snap_name> --visibility <public|private|internal> [options]
 
 Create and configure a new inference snap repository under ${REPOSITORY_OWNER}.
 
 Required arguments:
-  --model <model_name>   Model name used in the repository description.
-  --snap <snap_name>     Snap store name. Must be lowercase and contain only
+  --model <model_name>      Model name used in the repository description.
+  --snap <snap_name>        Snap store name. Must be lowercase and contain only
                          letters, digits, and single dashes.
+  --visibility <visibility> Repository visibility: public, private, or internal.
 
 Optional arguments:
-  --repo <repo_name>     Repository name. Defaults to <snap_name>-snap.
-  --private              Create the repository as private. Defaults to public.
-  --assume-yes           Skip confirmation prompts.
-  --dry-run              Print GitHub commands without executing them.
-  --help                 Show this help message and exit.
+  --repo <repo_name>        Repository name. Defaults to <snap_name>-snap.
+  --assume-yes              Skip confirmation prompts.
+  --dry-run                 Print GitHub commands without executing them.
+  --help                    Show this help message and exit.
 
 Environment overrides:
   REPOSITORY_OWNER, TEAM_NAME, CLI_TOOL, DRY_RUN
 
 Examples:
-  $0 --model model5 --snap model5
-  $0 --model "Model 3.5 Flash" --snap "model3-5-flash" --repo custom-repo --private --assume-yes
+  $0 --model model5 --snap model5 --visibility public
+  $0 --model "Model 3.5 Flash" --snap "model3-5-flash" --repo custom-repo --visibility private --assume-yes
 EOF
 }
 
@@ -115,9 +115,10 @@ parse_args() {
                 repo_name="$2"
                 shift 2
                 ;;
-            --private)
-                private=true
-                shift
+            --visibility)
+                [[ $# -ge 2 ]] || fail "--visibility requires a value"
+                visibility="$2"
+                shift 2
                 ;;
             --assume-yes)
                 assume_yes=true
@@ -141,6 +142,15 @@ parse_args() {
 validate_inputs() {
     [[ -n "$model_name" ]] || fail "--model is required and cannot be empty"
     [[ -n "$snap_name" ]] || fail "--snap is required and cannot be empty"
+    [[ -n "$visibility" ]] || fail "--visibility is required and cannot be empty"
+
+    case "$visibility" in
+        public|private|internal)
+            ;;
+        *)
+            fail "invalid visibility '$visibility'. Expected 'public', 'private', or 'internal'."
+            ;;
+    esac
 
     validate_snap_name "$snap_name"
 
@@ -150,13 +160,8 @@ validate_inputs() {
 }
 
 create_repo() {
-    local visibility_flag="--public"
-    if [[ "$private" == true ]]; then
-        visibility_flag="--private"
-    fi
-
     echo "Creating repository ${REPOSITORY_OWNER}/${repo_name}..."
-    gh_cmd repo create "${REPOSITORY_OWNER}/${repo_name}" "$visibility_flag"
+    gh_cmd repo create "${REPOSITORY_OWNER}/${repo_name}" "--${visibility}"
 
     echo "Applying repository-level settings after creation..."
     gh_api_json PATCH "/repos/${REPOSITORY_OWNER}/${repo_name}" "$(cat <<EOF

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -110,7 +110,7 @@ add_branch_rules() {
         {
             "actor_id": 5,
             "actor_type": "RepositoryRole",
-            "bypass_mode": "always"
+            "bypass_mode": "pull_request"
         }
     ],
     "conditions": {
@@ -134,11 +134,15 @@ add_branch_rules() {
         {
             "type": "pull_request",
             "parameters": {
-                "dismiss_stale_reviews_on_push": true,
+                "required_approving_review_count": 1,
+                "dismiss_stale_reviews_on_push": false,
+                "required_reviewers": [],
                 "require_code_owner_review": false,
                 "require_last_push_approval": false,
-                "required_approving_review_count": 1,
-                "required_review_thread_resolution": true
+                "required_review_thread_resolution": false,
+                "allowed_merge_methods": [
+                    "squash"
+                ]
             }
         },
         {

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -4,13 +4,13 @@ set -euo pipefail
 
 # Configuration variables
 RULESET_FILE=${RULESET_FILE:-"data/repository/default_ruleset.json"}
-REPOSITORY_OWNER="${REPOSITORY_OWNER:-canonical}"
 CLI_TOOL="${CLI_TOOL:-gh}"
 
 # Global variables
 model_name=""
 snap_name=""
 repo_name=""
+repo_owner=""
 team_slug=""
 visibility=""
 dry_run=false
@@ -71,15 +71,16 @@ ask_yes_no() {
 
 print_help() {
     cat <<EOF
-Usage: $0 --model <model_name> --snap <snap_name> --visibility <public|private|internal> [options]
+Usage: $0 --model <model_name> --snap <snap_name> --visibility <public|private|internal> --owner <owner> [options]
 
-Create and configure a new inference snap repository under ${REPOSITORY_OWNER}.
+Create and configure a new inference snap repository.
 
 Required arguments:
   --model <model_name>      Model name used in the repository description.
   --snap <snap_name>        Snap store name. Must be lowercase and contain only
                             letters, digits, and single dashes.
   --visibility <visibility> Repository visibility: public, private, or internal.
+  --owner <owner>           Repository owner (user or organization).
 
 Optional arguments:
   --add-team <team_slug>    Add a team with direct access (admin permissions) to the repository.
@@ -90,11 +91,11 @@ Optional arguments:
   --help                    Show this help message and exit.
 
 Environment overrides:
-  REPOSITORY_OWNER, CLI_TOOL, RULESET_FILE
+  CLI_TOOL, RULESET_FILE
 
 Examples:
-  $0 --model model5 --snap model5 --visibility public
-  $0 --model "Model 3.5 Flash" --snap "model3-5-flash" --repo custom-repo --visibility private --assume-yes
+  $0 --model model5 --snap model5 --visibility public --owner canonical
+  $0 --model "Model 3.5 Flash" --snap "model3-5-flash" --owner canonical --repo custom-repo --visibility private --assume-yes
 EOF
 }
 
@@ -122,6 +123,11 @@ parse_args() {
             --snap)
                 [[ $# -ge 2 ]] || fail "--snap requires a value"
                 snap_name="$2"
+                shift 2
+                ;;
+            --owner)
+                [[ $# -ge 2 ]] || fail "--owner requires a value"
+                repo_owner="$2"
                 shift 2
                 ;;
             --repo)
@@ -166,13 +172,13 @@ validate_team_slug() {
     [[ -n "$team_slug" ]] || return 0
 
     if [[ "$dry_run" == true ]]; then
-        echo "Dry run: skipping team existence check for @${REPOSITORY_OWNER}/${team_slug}."
+        echo "Dry run: skipping team existence check for @${repo_owner}/${team_slug}."
         return 0
     fi
 
-    echo "Validating team @${REPOSITORY_OWNER}/${team_slug} exists..."
-    if ! "$CLI_TOOL" api "/orgs/${REPOSITORY_OWNER}/teams/${team_slug}" >/dev/null 2>&1; then
-        fail "team '@${REPOSITORY_OWNER}/${team_slug}' not found or inaccessible."
+    echo "Validating team @${repo_owner}/${team_slug} exists..."
+    if ! "$CLI_TOOL" api "/orgs/${repo_owner}/teams/${team_slug}" >/dev/null 2>&1; then
+        fail "team '@${repo_owner}/${team_slug}' not found or inaccessible."
     fi
 }
 
@@ -180,6 +186,7 @@ validate_inputs() {
     [[ -n "$model_name" ]] || fail "--model is required and cannot be empty"
     [[ -n "$snap_name" ]] || fail "--snap is required and cannot be empty"
     [[ -n "$visibility" ]] || fail "--visibility is required and cannot be empty"
+    [[ -n "$repo_owner" ]] || fail "--owner is required and cannot be empty"
 
     case "$visibility" in
         public|private|internal)
@@ -198,20 +205,20 @@ validate_inputs() {
 }
 
 create_repo() {
-    echo "Creating repository ${REPOSITORY_OWNER}/${repo_name}..."
+    echo "Creating repository ${repo_owner}/${repo_name}..."
     
     local repo_description="Local inference with ${model_name}"
     local repo_homepage="https://snapcraft.io/${snap_name}"
 
     # Create repo
-    gh_cmd repo create "${REPOSITORY_OWNER}/${repo_name}" \
+    gh_cmd repo create "${repo_owner}/${repo_name}" \
         "--${visibility}" \
         --description "$repo_description" \
         --homepage "$repo_homepage"
 
     # Add topic
     echo "Setting repository topic..."
-    gh_api_json PUT "/repos/${REPOSITORY_OWNER}/${repo_name}/topics" "$(cat <<EOF
+    gh_api_json PUT "/repos/${repo_owner}/${repo_name}/topics" "$(cat <<EOF
 {
     "names": [
         "inference-snap"
@@ -221,7 +228,7 @@ EOF
 )"
     # Customize settings after creation, since some settings (e.g. squash merge) can't be set during creation
     echo "Applying repository-level settings after creation..."
-    gh_api_json PATCH "/repos/${REPOSITORY_OWNER}/${repo_name}" "$(cat <<EOF
+    gh_api_json PATCH "/repos/${repo_owner}/${repo_name}" "$(cat <<EOF
 {
     "has_wiki": false,
     "has_issues": false,
@@ -246,20 +253,20 @@ add_team_permissions() {
     # API specification: https://docs.github.com/en/rest/teams/teams?apiVersion=2026-03-10#add-or-update-team-repository-permissions
     # Permission levels: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permission-levels-for-repositories-owned-by-an-organization
 
-    echo "Granting team permissions to @${REPOSITORY_OWNER}/${team_slug}..."
-    gh_api_json PUT "/orgs/${REPOSITORY_OWNER}/teams/${team_slug}/repos/${REPOSITORY_OWNER}/${repo_name}" "{\"permission\": \"admin\"}"
+    echo "Granting team permissions to @${repo_owner}/${team_slug}..."
+    gh_api_json PUT "/orgs/${repo_owner}/teams/${team_slug}/repos/${repo_owner}/${repo_name}" "{\"permission\": \"admin\"}"
 }
 
 add_branch_rules() {
     echo "Creating branch ruleset for the default branch..."
-    gh_api_json POST "/repos/${REPOSITORY_OWNER}/${repo_name}/rulesets" "$(cat "$RULESET_FILE")"
+    gh_api_json POST "/repos/${repo_owner}/${repo_name}/rulesets" "$(cat "$RULESET_FILE")"
 }
 
 add_workflow_trigger_labels() {
     echo "Creating workflow trigger labels..."
 
-    gh_cmd label create --force trigger-build --repo "${REPOSITORY_OWNER}/${repo_name}" --color EEEEEE --description "Trigger build pipeline and publish snap"
-    gh_cmd label create --force trigger-tests --repo "${REPOSITORY_OWNER}/${repo_name}" --color 666666 --description "Trigger test pipeline on last build, if not present triggers also build"
+    gh_cmd label create --force trigger-build --repo "${repo_owner}/${repo_name}" --color EEEEEE --description "Trigger build pipeline and publish snap"
+    gh_cmd label create --force trigger-tests --repo "${repo_owner}/${repo_name}" --color 666666 --description "Trigger test pipeline on last build, if not present triggers also build"
 }
 
 main() {
@@ -297,7 +304,7 @@ main() {
     echo "  - Repository visibility: $visibility"
     echo "  - Team with admin access: ${team_slug:-none}"
     echo ""
-    echo "Once created, the repository will be available at https://www.github.com/$REPOSITORY_OWNER/$repo_name"
+    echo "Once created, the repository will be available at https://www.github.com/$repo_owner/$repo_name"
     echo ""
 
     # Confirmation
@@ -316,7 +323,7 @@ main() {
 
     # Completion message
     echo "Repository setup complete!"
-    echo "Access it here: https://www.github.com/$REPOSITORY_OWNER/$repo_name"
+    echo "Access it here: https://www.github.com/$repo_owner/$repo_name"
 }
 
 main "$@"

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -35,16 +35,20 @@ gh_api_json() {
     local method="$1"
     local endpoint="$2"
     local payload="$3"
+    local response=""
+    local status=0
 
     if [[ "$dry_run" == true ]]; then
         print_cmd "$CLI_TOOL" api --method "$method" "$endpoint" --input -
         printf "%s\n" "$payload"
     else
-        if [[ "$debug" == true ]]; then
-            printf "%s\n" "$payload" | "$CLI_TOOL" api --method "$method" "$endpoint" --input -
-        else
-            # Response body is not needed; suppress it to avoid pager/full-screen output.
-            printf "%s\n" "$payload" | "$CLI_TOOL" api --method "$method" "$endpoint" --input - >/dev/null
+        # Keep successful calls quiet, but print API output when a call fails.
+        response="$(printf "%s\n" "$payload" | "$CLI_TOOL" api --method "$method" "$endpoint" --input - 2>&1)" || status=$?
+        if [[ "$status" -ne 0 || "$debug" == true ]]; then
+            if [[ -n "$response" ]]; then
+                printf "%s\n" "$response" >&2
+            fi
+            return "$status"
         fi
     fi
 }

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -78,7 +78,7 @@ Optional arguments:
   --help                    Show this help message and exit.
 
 Environment overrides:
-  REPOSITORY_OWNER, TEAM_NAME, CLI_TOOL, DRY_RUN, RULESET_FILE
+  REPOSITORY_OWNER, TEAM_NAME, CLI_TOOL, RULESET_FILE
 
 Examples:
   $0 --model model5 --snap model5 --visibility public

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -92,7 +92,7 @@ Optional arguments:
   --assume-yes              Skip confirmation prompts.
   --debug                   Show full GitHub API responses.
   --dry-run                 Print GitHub commands without executing them.
-  --help                    Show this help message and exit.
+  -h, --help                    Show this help message and exit.
 
 Environment overrides:
   CLI_TOOL                  Command-line tool for GitHub interactions (default: gh).
@@ -202,7 +202,7 @@ parse_args() {
                 dry_run=true
                 shift
                 ;;
-            --help)
+            -h|--help)
                 print_help
                 exit 0
                 ;;

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -241,8 +241,8 @@ add_branch_rules() {
 add_workflow_trigger_labels() {
     echo "Creating workflow trigger labels..."
 
-    gh_cmd label create --force trigger-build --repo "${REPOSITORY_OWNER}/${repo_name}" --color 78AF54 --description "Trigger build pipeline and publish snap"
-    gh_cmd label create --force trigger-tests --repo "${REPOSITORY_OWNER}/${repo_name}" --color 9A1F77 --description "Trigger test pipeline on last build, if not present triggers also build"
+    gh_cmd label create --force trigger-build --repo "${REPOSITORY_OWNER}/${repo_name}" --color EEEEEE --description "Trigger build pipeline and publish snap"
+    gh_cmd label create --force trigger-tests --repo "${REPOSITORY_OWNER}/${repo_name}" --color 666666 --description "Trigger test pipeline on last build, if not present triggers also build"
 }
 
 main() {

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -162,6 +162,20 @@ parse_args() {
     done
 }
 
+validate_team_slug() {
+    [[ -n "$team_slug" ]] || return 0
+
+    if [[ "$dry_run" == true ]]; then
+        echo "Dry run: skipping team existence check for @${REPOSITORY_OWNER}/${team_slug}."
+        return 0
+    fi
+
+    echo "Validating team @${REPOSITORY_OWNER}/${team_slug} exists..."
+    if ! "$CLI_TOOL" api "/orgs/${REPOSITORY_OWNER}/teams/${team_slug}" >/dev/null 2>&1; then
+        fail "team '@${REPOSITORY_OWNER}/${team_slug}' not found or inaccessible."
+    fi
+}
+
 validate_inputs() {
     [[ -n "$model_name" ]] || fail "--model is required and cannot be empty"
     [[ -n "$snap_name" ]] || fail "--snap is required and cannot be empty"
@@ -270,6 +284,8 @@ main() {
         fi
     fi
 
+    validate_team_slug
+
     # Summary
     echo ""
     echo "Repository will be created with the following settings:"
@@ -277,6 +293,7 @@ main() {
     echo "  - Repository name: $repo_name"
     echo "  - Snap name: $snap_name"
     echo "  - Repository visibility: $visibility"
+    echo "  - Team with admin access: ${team_slug:-none}"
     echo ""
     echo "Once created, the repository will be available at https://www.github.com/$REPOSITORY_OWNER/$repo_name"
     echo ""

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -1,11 +1,39 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 # Configuration variables
 REPOSITORY_OWNER="canonical"
 TEAM_NAME="industrial"
-CLI_TOOL="gh_disabled" # GitHub CLI tool # TODO: change to gh when ready, for now we disable it to avoid accidental execution while the script is being developed
+CLI_TOOL="gh"
+DRY_RUN=false
+
+print_cmd() {
+    printf "+ "
+    printf "%q " "$@"
+    printf "\n"
+}
+
+gh_cmd() {
+    if [[ "$DRY_RUN" == true ]]; then
+        print_cmd "$CLI_TOOL" "$@"
+    else
+        "$CLI_TOOL" "$@"
+    fi
+}
+
+gh_api_json() {
+    local method="$1"
+    local endpoint="$2"
+    local payload="$3"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        print_cmd "$CLI_TOOL" api --method "$method" "$endpoint" --input -
+        printf "%s\n" "$payload"
+    else
+        printf "%s\n" "$payload" | "$CLI_TOOL" api --method "$method" "$endpoint" --input -
+    fi
+}
 
 ask_yes_no() {
     read -p "$1 (y/N): " response
@@ -27,10 +55,41 @@ create_repo() {
 #   - Enable "Allow auto-merge"
 #   - Enable "Automatically delete head branches"
 #   - Enable main branch protection rules (require pull request reviews before merging, require status checks to pass before merging, require branches to be up to date before merging)
+
+    local visibility_flag="--public"
+    if [[ "$private" == true ]]; then
+        visibility_flag="--private"
+    fi
+
+    echo "Creating repository ${REPOSITORY_OWNER}/${repo_name}..."
+    gh_cmd repo create "${REPOSITORY_OWNER}/${repo_name}" "$visibility_flag"
+
+    # Apply repository-level settings after creation.
+    gh_api_json PATCH "/repos/${REPOSITORY_OWNER}/${repo_name}" "$(cat <<EOF
+{
+    "has_wiki": false,
+    "has_issues": false,
+    "has_projects": false,
+    "allow_merge_commit": false,
+    "allow_rebase_merge": false,
+    "allow_squash_merge": true,
+    "allow_update_branch": true,
+    "allow_auto_merge": true,
+    "delete_branch_on_merge": true
+}
+EOF
+)"
 }
 
 add_team_permissions() {
-#  - Add "@canonical/industrial" team with direct access (admin permissions)
+    #  - Add REPOSITORY_OWNER/TEAM_NAME (e.g. "@canonical/industrial") team with direct access (admin permissions)
+    echo "Granting team permissions to @${REPOSITORY_OWNER}/${TEAM_NAME}..."
+    gh_api_json PUT "/orgs/${REPOSITORY_OWNER}/teams/${TEAM_NAME}/repos/${REPOSITORY_OWNER}/${repo_name}" "$(cat <<EOF
+{
+    "permission": "admin"
+}
+EOF
+)"
 }
 
 add_branch_rules() {
@@ -41,17 +100,90 @@ add_branch_rules() {
 #       - Require signed commits
 #       - Require a pull request before merging
 #       - Block force pushes
+    echo "Creating branch ruleset for the default branch..."
+    gh_api_json POST "/repos/${REPOSITORY_OWNER}/${repo_name}/rulesets" "$(cat <<EOF
+{
+    "name": "main-branch-protection",
+    "target": "branch",
+    "enforcement": "active",
+    "bypass_actors": [
+        {
+            "actor_id": 5,
+            "actor_type": "RepositoryRole",
+            "bypass_mode": "always"
+        }
+    ],
+    "conditions": {
+        "ref_name": {
+            "include": [
+                "~DEFAULT_BRANCH"
+            ],
+            "exclude": []
+        }
+    },
+    "rules": [
+        {
+            "type": "deletion"
+        },
+        {
+            "type": "non_fast_forward"
+        },
+        {
+            "type": "required_signatures"
+        },
+        {
+            "type": "pull_request",
+            "parameters": {
+                "dismiss_stale_reviews_on_push": true,
+                "require_code_owner_review": false,
+                "require_last_push_approval": false,
+                "required_approving_review_count": 1,
+                "required_review_thread_resolution": true
+            }
+        },
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "do_not_enforce_on_create": false,
+                "required_status_checks": [],
+                "strict_required_status_checks_policy": true
+            }
+        }
+    ]
+}
+EOF
+)"
 }
 
 add_website_and_description() {
 #   - Add description: "Local inference with ${model_name}"
 #   - Add website: "https://snapcraft.io/${model_name}"
 #   - Add Topic: "inference-snap"
+    echo "Setting repository description, website, and topic..."
+    gh_api_json PATCH "/repos/${REPOSITORY_OWNER}/${repo_name}" "$(cat <<EOF
+{
+    "description": "Local inference with ${model_name}",
+    "homepage": "https://snapcraft.io/${model_name}"
+}
+EOF
+)"
+
+    gh_api_json PUT "/repos/${REPOSITORY_OWNER}/${repo_name}/topics" "$(cat <<EOF
+{
+    "names": [
+        "inference-snap"
+    ]
+}
+EOF
+)"
 }
 
 add_workflow_trigger_labels() {
 #   - Add label "trigger-build" with description "Trigger build pipeline and publish snap"
 #   - Add label "trigger-tests" with description "Trigger test pipeline on last build, if not present triggers also build"
+    echo "Creating workflow trigger labels..."
+    gh_cmd label create trigger-build --repo "${REPOSITORY_OWNER}/${repo_name}" --color 78af54 --description "Trigger build pipeline and publish snap" --force
+    gh_cmd label create trigger-tests --repo "${REPOSITORY_OWNER}/${repo_name}" --color 9a1f77 --description "Trigger test pipeline on last build, if not present triggers also build" --force
 }
 
 print_help() {
@@ -66,24 +198,40 @@ print_help() {
 
 main() {
     # Read parameters (--help or --dry-run)
-    if [[ "$1" == "--dry-run" ]]; then
+    for arg in "$@"; do
+        case "$arg" in
+            --dry-run)
+                DRY_RUN=true
+                ;;
+            --help)
+                print_help
+                exit 0
+                ;;
+            *)
+                echo "Error: unknown argument '$arg'"
+                print_help
+                exit 1
+                ;;
+        esac
+    done
+
+    if [[ "$DRY_RUN" == true ]]; then
         echo "Dry run mode: no changes will be made to GitHub."
-        CLI_TOOL="echo $CLI_TOOL (dry run)"
-    elif [[ "$1" == "--help" ]]; then
-        print_help
-        exit 0
     fi
-
-
 
     echo "This script will guide you into the creation and setup of a new repository for an inference snap."
     echo ""
 
     # Check if GitHub CLI is installed
-    if ! command -v $CLI_TOOL &> /dev/null; then
-        echo "Error: GitHub CLI ($CLI_TOOL) is required, but not installed. You can install it from https://cli.github.com/."
-        exit 1
-    fi
+    # if ! command -v "$CLI_TOOL" &> /dev/null; then
+    #     echo "Error: GitHub CLI ($CLI_TOOL) is required, but not installed. You can install it from https://cli.github.com/."
+    #     exit 1
+    # fi
+# 
+    # if [[ "$DRY_RUN" == false ]] && ! "$CLI_TOOL" auth status >/dev/null 2>&1; then
+    #     echo "Error: GitHub CLI is not authenticated. Run 'gh auth login' first."
+    #     exit 1
+    # fi
 
     # Data input: model name
     read -p "> Enter the AI model name (e.g. 'model5'): " model_name
@@ -117,7 +265,7 @@ main() {
     echo "  - Model name: $model_name"
     echo "  - Repository name: $repo_name"
     echo "  - Snap name: $snap_name"
-    echo "  - Repository visibility: $([[ "$private" == true ]] && echo "Private" || echo "Public")"
+    echo "  - Repository visibility: $([[ "$private" == true ]] && echo "private" || echo "public")"
     echo ""
 
     if ! ask_yes_no "> Do you want to proceed with these settings?"; then
@@ -137,4 +285,4 @@ main() {
     echo "Access it here: https://www.github.com/$REPOSITORY_OWNER/$repo_name"
 }
 
-main
+main "$@"

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -76,12 +76,7 @@ EOF
 add_team_permissions() {
     # Add REPOSITORY_OWNER/TEAM_NAME (e.g. "@canonical/industrial") team with direct access (admin permissions)
     echo "Granting team permissions to @${REPOSITORY_OWNER}/${TEAM_NAME}..."
-    gh_api_json PUT "/orgs/${REPOSITORY_OWNER}/teams/${TEAM_NAME}/repos/${REPOSITORY_OWNER}/${repo_name}" "$(cat <<EOF
-{
-    "permission": "admin"
-}
-EOF
-)"
+    gh_api_json PUT "/orgs/${REPOSITORY_OWNER}/teams/${TEAM_NAME}/repos/${REPOSITORY_OWNER}/${repo_name}" "{\"permission\": \"admin\"}"
 }
 
 add_branch_rules() {
@@ -115,8 +110,8 @@ EOF
 add_workflow_trigger_labels() {
     echo "Creating workflow trigger labels..."
 
-    gh_cmd label create trigger-build --repo "${REPOSITORY_OWNER}/${repo_name}" --color 78AF54 --description "Trigger build pipeline and publish snap" --force
-    gh_cmd label create trigger-tests --repo "${REPOSITORY_OWNER}/${repo_name}" --color 9A1F77 --description "Trigger test pipeline on last build, if not present triggers also build" --force
+    gh_cmd label create --force trigger-build --repo "${REPOSITORY_OWNER}/${repo_name}" --color 78AF54 --description "Trigger build pipeline and publish snap"
+    gh_cmd label create --force trigger-tests --repo "${REPOSITORY_OWNER}/${repo_name}" --color 9A1F77 --description "Trigger test pipeline on last build, if not present triggers also build"
 }
 
 print_help() {

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -5,13 +5,13 @@ set -euo pipefail
 # Configuration variables
 RULESET_FILE=${RULESET_FILE:-"data/repository/default_ruleset.json"}
 REPOSITORY_OWNER="${REPOSITORY_OWNER:-canonical}"
-TEAM_SLUG="${TEAM_SLUG:-industrial}"
 CLI_TOOL="${CLI_TOOL:-gh}"
 
 # Global variables
 model_name=""
 snap_name=""
 repo_name=""
+team_slug=""
 visibility=""
 dry_run=false
 assume_yes=false
@@ -82,6 +82,7 @@ Required arguments:
   --visibility <visibility> Repository visibility: public, private, or internal.
 
 Optional arguments:
+  --add-team <team_slug>    Add a team with direct access (admin permissions) to the repository.
   --repo <repo_name>        Repository name. Defaults to <snap_name>-snap.
   --assume-yes              Skip confirmation prompts.
   --debug                   Show full GitHub API responses.
@@ -89,7 +90,7 @@ Optional arguments:
   --help                    Show this help message and exit.
 
 Environment overrides:
-  REPOSITORY_OWNER, TEAM_SLUG, CLI_TOOL, RULESET_FILE
+  REPOSITORY_OWNER, CLI_TOOL, RULESET_FILE
 
 Examples:
   $0 --model model5 --snap model5 --visibility public
@@ -126,6 +127,11 @@ parse_args() {
             --repo)
                 [[ $# -ge 2 ]] || fail "--repo requires a value"
                 repo_name="$2"
+                shift 2
+                ;;
+            --add-team)
+                [[ $# -ge 2 ]] || fail "--add-team requires a value"
+                team_slug="$2"
                 shift 2
                 ;;
             --visibility)
@@ -217,14 +223,14 @@ EOF
 }
 
 add_team_permissions() {
-    # Add REPOSITORY_OWNER/TEAM_SLUG (e.g. "@canonical/industrial") team with direct access (admin permissions)
+    # Add REPOSITORY_OWNER/team_slug (e.g. "@canonical/industrial") team with direct access (admin permissions)
     # Doing this with "--team" during repo creation isn't reliable, see here: https://github.com/cli/cli/discussions/6906
 
     # API specification: https://docs.github.com/en/rest/teams/teams?apiVersion=2026-03-10#add-or-update-team-repository-permissions
     # Permission levels: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permission-levels-for-repositories-owned-by-an-organization
 
-    echo "Granting team permissions to @${REPOSITORY_OWNER}/${TEAM_SLUG}..."
-    gh_api_json PUT "/orgs/${REPOSITORY_OWNER}/teams/${TEAM_SLUG}/repos/${REPOSITORY_OWNER}/${repo_name}" "{\"permission\": \"admin\"}"
+    echo "Granting team permissions to @${REPOSITORY_OWNER}/${team_slug}..."
+    gh_api_json PUT "/orgs/${REPOSITORY_OWNER}/teams/${team_slug}/repos/${REPOSITORY_OWNER}/${repo_name}" "{\"permission\": \"admin\"}"
 }
 
 add_branch_rules() {
@@ -285,7 +291,9 @@ main() {
     # Execution
     create_repo
     add_workflow_trigger_labels
-    add_team_permissions
+    if [[ -n "$team_slug" ]]; then
+        add_team_permissions
+    fi
     add_branch_rules
 
     # Completion message

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -99,12 +99,12 @@ Environment overrides:
 
 Examples:
   $0 --model model5 --snap model5 --visibility public --owner canonical
-  $0 --model "Model 3.5 Flash" \
-    --snap "model3-5-flash" \
-    --owner canonical \
-    --repo custom-repo \
-    --visibility private \
-    --add-ruleset data/repository/default_ruleset.json \
+  $0 --model "Model 3.5 Flash" \\
+    --snap "model3-5-flash" \\
+    --owner canonical \\
+    --repo custom-repo \\
+    --visibility private \\
+    --add-ruleset data/repository/default_ruleset.json \\
     --assume-yes
 EOF
 }

--- a/repo-setup.sh
+++ b/repo-setup.sh
@@ -219,15 +219,15 @@ main() {
     echo ""
 
     # Check if GitHub CLI is installed
-    # if ! command -v "$CLI_TOOL" &> /dev/null; then
-    #     echo "Error: GitHub CLI ($CLI_TOOL) is required, but not installed. You can install it from https://cli.github.com/."
-    #     exit 1
-    # fi
-# 
-    # if [[ "$DRY_RUN" == false ]] && ! "$CLI_TOOL" auth status >/dev/null 2>&1; then
-    #     echo "Error: GitHub CLI is not authenticated. Run 'gh auth login' first."
-    #     exit 1
-    # fi
+    if ! command -v "$CLI_TOOL" &> /dev/null; then
+        echo "Error: GitHub CLI ($CLI_TOOL) is required, but not installed. You can install it from https://cli.github.com/."
+        exit 1
+    fi
+
+    if [[ "$DRY_RUN" == false ]] && ! "$CLI_TOOL" auth status >/dev/null 2>&1; then
+        echo "Error: GitHub CLI is not authenticated. Run 'gh auth login' first."
+        exit 1
+    fi
 
     # Data input: model name
     read -p "> Enter the AI model name (e.g. 'model5'): " model_name


### PR DESCRIPTION
This PR adds a new bash script used to automate the repository setup process for an inference snap. It will:

1. Create a repository with a given visibility (private, internal, public)
2. Add homepage and description for the repository
3. Add common labels
4. Setup repository settings
5. Add team permissions
6. Add branch rules