### PR TITLE
Add snap registration script

### DIFF
--- a/register-snap.sh
+++ b/register-snap.sh
@@ -6,7 +6,6 @@ CLI_TOOL="${CLI_TOOL:-snapcraft}"
 
 snap_name=""
 visibility=""
-collaborator_emails_csv=""
 assume_yes=false
 dry_run=false
 
@@ -41,16 +40,13 @@ usage() {
     cat <<EOF
 Usage: $0 --snap <snap_name> --visibility <value> [options]
 
-Register a snap in the store. Any collaborators will need to be added manually via the snapcraft dashboard.
+Register a snap in the store.
 
 Required arguments:
   --snap <snap_name>            Snap name to register.
   --visibility <value>          Snap visibility: public or private
 
 Optional arguments:
-  --collaborators <csv>         Comma-separated collaborator email list, e.g. "a@example.com,b@example.com".
-                                Can be provided multiple times to append more emails.
-                                Collaborators must still be added manually via the dashboard.
   --assume-yes                  Skip confirmation prompt.
   --dry-run                     Print commands without executing them.
   -h, --help                    Show this help message and exit.
@@ -59,8 +55,8 @@ Environment overrides:
   CLI_TOOL                      Path to the CLI binary to use (default: snapcraft).
 
 Examples:
-  $0 --snap deepseek-r1 --visibility private --collaborators dev@example.com
-  $0 --snap deepseek-r1 --visibility public --collaborators "a@example.com,b@example.com"
+  $0 --snap deepseek-r1 --visibility private
+  $0 --snap deepseek-r1 --visibility public
 EOF
 }
 
@@ -69,7 +65,7 @@ ask_yes_no() {
         return 0
     fi
 
-    if ! read -r -p "$1 (y/N): " response; then
+    if ! read -r -p "$1 [y/N] " response; then
         return 1
     fi
 
@@ -94,17 +90,6 @@ parse_args() {
             --visibility)
                 [[ $# -ge 2 ]] || fail "--visibility requires a value"
                 visibility="$2"
-                shift 2
-                ;;
-            --collaborators)
-                [[ $# -ge 2 ]] || fail "--collaborators requires a value"
-                if [[ -z "$collaborator_emails_csv" ]]; then
-                    # Init
-                    collaborator_emails_csv="$2"
-                else
-                    # Append
-                    collaborator_emails_csv="$collaborator_emails_csv,$2"
-                fi
                 shift 2
                 ;;
             --assume-yes)
@@ -182,7 +167,7 @@ main() {
     echo "  - Visibility: $visibility"
     echo ""
 
-    if ! ask_yes_no "> Continue?"; then
+    if ! ask_yes_no "Continue?"; then
         echo "Aborting."
         exit 0
     fi
@@ -190,16 +175,7 @@ main() {
     register_snap
 
     echo ""
-    echo "Snap setup complete for '$snap_name'."
-    echo "Please visit the snapcraft dashboard to add collaborators:"
-    echo "  https://dashboard.snapcraft.io/snaps/$snap_name/collaboration/"
-
-    if [[ -n "$collaborator_emails_csv" ]]; then
-        echo ""
-        echo "Collaborators:"
-        echo "  $collaborator_emails_csv"
-        echo ""
-    fi
+    echo "Snapcraft dashboard:  https://dashboard.snapcraft.io/snaps/$snap_name"
 }
 
 main "$@"

--- a/snap-setup.sh
+++ b/snap-setup.sh
@@ -182,7 +182,7 @@ main() {
     echo "  - Visibility: $visibility"
     echo ""
 
-    if ! ask_yes_no "> Continue"; then
+    if ! ask_yes_no "> Continue?"; then
         echo "Aborting."
         exit 0
     fi

--- a/snap-setup.sh
+++ b/snap-setup.sh
@@ -154,13 +154,13 @@ ensure_snapcraft_logged_in() {
 }
 
 register_snap() {
-    local visibility_arg=""
+    local register_args=(register "$snap_name" --yes)
+    
     if [[ "$visibility" == "private" ]]; then
-        visibility_arg="--private"
+        register_args+=("--private")
     fi
 
 	echo "Registering snap '$snap_name' with visibility '$visibility'..."
-	local register_args=(register "$snap_name" "$visibility_arg" --yes)
 	sc_cmd "${register_args[@]}"
 }
 

--- a/snap-setup.sh
+++ b/snap-setup.sh
@@ -11,34 +11,34 @@ assume_yes=false
 dry_run=false
 
 print_cmd() {
-	printf "+ "
-	printf "%q " "$@"
-	printf "\n"
+    printf "+ "
+    printf "%q " "$@"
+    printf "\n"
 }
 
 sc_cmd() {
-	if [[ "$dry_run" == true ]]; then
-		print_cmd "$CLI_TOOL" "$@"
-	else
-		"$CLI_TOOL" "$@"
-	fi
+    if [[ "$dry_run" == true ]]; then
+        print_cmd "$CLI_TOOL" "$@"
+    else
+        "$CLI_TOOL" "$@"
+    fi
 }
 
 fail() {
-	echo "Error: $1" >&2
-	exit 1
+    echo "Error: $1" >&2
+    exit 1
 }
 
 validate_snap_name() {
-	local value="$1"
+    local value="$1"
 
-	if [[ ! "$value" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
-		fail "invalid snap name '$value'. Expected lowercase letters, digits, and single dashes only."
-	fi
+    if [[ ! "$value" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+        fail "invalid snap name '$value'. Expected lowercase letters, digits, and single dashes only."
+    fi
 }
 
 usage() {
-	cat <<EOF
+    cat <<EOF
 Usage: $0 --snap <snap_name> --visibility <value> [options]
 
 Register a snap in the store. Any collaborators will need to be added manually via the snapcraft dashboard.
@@ -64,36 +64,36 @@ EOF
 }
 
 ask_yes_no() {
-	if [[ "$assume_yes" == true ]]; then
-		return 0
-	fi
+    if [[ "$assume_yes" == true ]]; then
+        return 0
+    fi
 
-	read -r -p "$1 (y/N): " response
-	case "$response" in
-		[yY][eE][sS]|[yY])
-			return 0
-			;;
-		*)
-			return 1
-			;;
-	esac
+    read -r -p "$1 (y/N): " response
+    case "$response" in
+        [yY][eE][sS]|[yY])
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 parse_args() {
-	while [[ $# -gt 0 ]]; do
-		case "$1" in
-			--snap)
-				[[ $# -ge 2 ]] || fail "--snap requires a value"
-				snap_name="$2"
-				shift 2
-				;;
-			--visibility)
-				[[ $# -ge 2 ]] || fail "--visibility requires a value"
-				visibility="$2"
-				shift 2
-				;;
-			--collaborators)
-				[[ $# -ge 2 ]] || fail "--collaborators requires a value"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --snap)
+                [[ $# -ge 2 ]] || fail "--snap requires a value"
+                snap_name="$2"
+                shift 2
+                ;;
+            --visibility)
+                [[ $# -ge 2 ]] || fail "--visibility requires a value"
+                visibility="$2"
+                shift 2
+                ;;
+            --collaborators)
+                [[ $# -ge 2 ]] || fail "--collaborators requires a value"
                 if [[ -z "$collaborator_emails_csv" ]]; then
                     # Init
                     collaborator_emails_csv="$2"
@@ -101,57 +101,57 @@ parse_args() {
                     # Append
                     collaborator_emails_csv="$collaborator_emails_csv,$2"
                 fi
-				shift 2
-				;;
-			--assume-yes)
-				assume_yes=true
-				shift
-				;;
-			--dry-run)
-				dry_run=true
-				shift
-				;;
-			-h|--help)
-				usage
-				exit 0
-				;;
-			*)
-				fail "unknown argument '$1'"
-				;;
-		esac
-	done
+                shift 2
+                ;;
+            --assume-yes)
+                assume_yes=true
+                shift
+                ;;
+            --dry-run)
+                dry_run=true
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                fail "unknown argument '$1'"
+                ;;
+        esac
+    done
 }
 
 validate_inputs() {
-	[[ -n "$snap_name" ]] || fail "--snap is required"
+    [[ -n "$snap_name" ]] || fail "--snap is required"
     [[ -n "$visibility" ]] || fail "--visibility is required"
 
-	validate_snap_name "$snap_name"
+    validate_snap_name "$snap_name"
 
-	case "$visibility" in
-		public|private)
-			;;
-		*)
-			fail "invalid visibility '$visibility'. Expected 'public' or 'private'."
-			;;
-	esac
+    case "$visibility" in
+        public|private)
+            ;;
+        *)
+            fail "invalid visibility '$visibility'. Expected 'public' or 'private'."
+            ;;
+    esac
 }
 
 ensure_snapcraft_available() {
-	if ! command -v "$CLI_TOOL" >/dev/null 2>&1; then
-		fail "'$CLI_TOOL' was not found. Install snapcraft by running: 'sudo snap install snapcraft --classic'"
-	fi
+    if ! command -v "$CLI_TOOL" >/dev/null 2>&1; then
+        fail "'$CLI_TOOL' was not found. Install snapcraft by running: 'sudo snap install snapcraft --classic'"
+    fi
 }
 
 ensure_snapcraft_logged_in() {
-	if [[ "$dry_run" == true ]]; then
-		echo "Dry run: skipping login status check."
-		return 0
-	fi
+    if [[ "$dry_run" == true ]]; then
+        echo "Dry run: skipping login status check."
+        return 0
+    fi
 
-	if ! "$CLI_TOOL" whoami >/dev/null 2>&1; then
-		fail "Snapcraft is not logged in. Run '$CLI_TOOL login' and retry."
-	fi
+    if ! "$CLI_TOOL" whoami >/dev/null 2>&1; then
+        fail "Snapcraft is not logged in. Run '$CLI_TOOL login' and retry."
+    fi
 }
 
 register_snap() {
@@ -161,31 +161,31 @@ register_snap() {
         register_args+=("--private")
     fi
 
-	echo "Registering snap '$snap_name' with visibility '$visibility'..."
-	sc_cmd "${register_args[@]}"
+    echo "Registering snap '$snap_name' with visibility '$visibility'..."
+    sc_cmd "${register_args[@]}"
 }
 
 main() {
-	parse_args "$@"
-	validate_inputs
+    parse_args "$@"
+    validate_inputs
 
-	ensure_snapcraft_available
-	ensure_snapcraft_logged_in
+    ensure_snapcraft_available
+    ensure_snapcraft_logged_in
 
-	echo ""
-	echo "The following setup will be applied:"
-	echo "  - Snap name: $snap_name"
-	echo "  - Visibility: $visibility"
-	echo ""
+    echo ""
+    echo "The following setup will be applied:"
+    echo "  - Snap name: $snap_name"
+    echo "  - Visibility: $visibility"
+    echo ""
 
-	if ! ask_yes_no "> Continue"; then
-		echo "Aborting."
-		exit 0
-	fi
+    if ! ask_yes_no "> Continue"; then
+        echo "Aborting."
+        exit 0
+    fi
 
-	register_snap
+    register_snap
 
-	echo "Snap setup complete for '$snap_name'."
+    echo "Snap setup complete for '$snap_name'."
     echo "Please visit the snapcraft dashboard to add collaborators:"
     echo "  https://dashboard.snapcraft.io/snaps/$snap_name/collaboration/"
     

--- a/snap-setup.sh
+++ b/snap-setup.sh
@@ -45,7 +45,7 @@ usage() {
 	cat <<EOF
 Usage: $0 --snap <snap_name> --visibility <value> [options]
 
-Register a snap in the store and optionally set initial metadata.
+Register a snap in the store.
 
 Required arguments:
   --snap <snap_name>            Snap name to register.
@@ -100,11 +100,6 @@ parse_args() {
                 collaborator_emails_csv=$([[ -z "$collaborator_emails_csv" ]] && echo "$2" || echo "$collaborator_emails_csv,$2") # Append
 				shift 2
 				;;
-			--set-metadata-from)
-                [[ $# -ge 2 ]] || fail "--set-metadata-from requires a value"
-				metadata_source_file="$2"
-				shift 2
-				;;
 			--assume-yes)
 				assume_yes=true
 				shift
@@ -127,7 +122,6 @@ parse_args() {
 validate_inputs() {
 	[[ -n "$snap_name" ]] || fail "--snap is required"
     [[ -n "$visibility" ]] || fail "--visibility is required"
-    [[ -n "$metadata_source_file" && ! -f "$metadata_source_file" ]] || fail "Cannot access metadata source file: $metadata_source_file"
 
 	validate_snap_name "$snap_name"
 
@@ -168,16 +162,6 @@ register_snap() {
 	sc_cmd "${register_args[@]}"
 }
 
-set_metadata(){
-    if [[ -z "${metadata_source_file:-}" ]]; then
-        echo "No metadata source file provided, skipping metadata upload."
-        return 0
-    fi
-
-    echo "Setting snap metadata from '$metadata_source_file'..."
-    sc_cmd "upload_metadata" "--force" "$metadata_source_file"
-}
-
 main() {
 	parse_args "$@"
 	validate_inputs
@@ -189,7 +173,6 @@ main() {
 	echo "The following setup will be applied:"
 	echo "  - Snap name: $snap_name"
 	echo "  - Visibility: $visibility"
-	echo "  - Snap metadata: $([[ -n "$metadata_source_file" ]] && echo "extracted from $metadata_source_file" || echo "unset")"
 	echo ""
 
 	if ! ask_yes_no "> Continue"; then
@@ -198,7 +181,6 @@ main() {
 	fi
 
 	register_snap
-    set_metadata
 
 	echo "Snap setup complete for '$snap_name'."
 

--- a/snap-setup.sh
+++ b/snap-setup.sh
@@ -50,6 +50,7 @@ Required arguments:
 Optional arguments:
   --collaborators <csv>         Comma-separated collaborator email list, e.g. "a@example.com,b@example.com".
                                 Can be provided multiple times to append more emails.
+                                Collaborators must still be added manually via the dashboard.
   --assume-yes                  Skip confirmation prompt.
   --dry-run                     Print commands without executing them.
   -h, --help                    Show this help message and exit.
@@ -68,7 +69,10 @@ ask_yes_no() {
         return 0
     fi
 
-    read -r -p "$1 (y/N): " response
+    if ! read -r -p "$1 (y/N): " response; then
+        return 1
+    fi
+
     case "$response" in
         [yY][eE][sS]|[yY])
             return 0
@@ -189,7 +193,7 @@ main() {
     echo "Snap setup complete for '$snap_name'."
     echo "Please visit the snapcraft dashboard to add collaborators:"
     echo "  https://dashboard.snapcraft.io/snaps/$snap_name/collaboration/"
-    
+
     if [[ -n "$collaborator_emails_csv" ]]; then
         echo ""
         echo "Collaborators:"

--- a/snap-setup.sh
+++ b/snap-setup.sh
@@ -41,7 +41,7 @@ usage() {
 	cat <<EOF
 Usage: $0 --snap <snap_name> --visibility <value> [options]
 
-Register a snap in the store.
+Register a snap in the store. Any collaborators will need to be added manually via the snapcraft dashboard.
 
 Required arguments:
   --snap <snap_name>            Snap name to register.
@@ -49,6 +49,7 @@ Required arguments:
 
 Optional arguments:
   --collaborators <csv>         Comma-separated collaborator email list, e.g. "a@example.com,b@example.com".
+                                Can be provided multiple times to append more emails.
   --assume-yes                  Skip confirmation prompt.
   --dry-run                     Print commands without executing them.
   -h, --help                    Show this help message and exit.
@@ -155,7 +156,7 @@ ensure_snapcraft_logged_in() {
 
 register_snap() {
     local register_args=(register "$snap_name" --yes)
-    
+
     if [[ "$visibility" == "private" ]]; then
         register_args+=("--private")
     fi

--- a/snap-setup.sh
+++ b/snap-setup.sh
@@ -186,9 +186,10 @@ main() {
 	register_snap
 
 	echo "Snap setup complete for '$snap_name'."
-
+    echo "Please visit the snapcraft dashboard to add collaborators:"
+    echo "  https://dashboard.snapcraft.io/snaps/$snap_name/collaboration/"
+    
     if [[ -n "$collaborator_emails_csv" ]]; then
-        echo "Please visit the snapcraft dashboard to add collaborators: https://dashboard.snapcraft.io/snaps/$snap_name/collaboration/"
         echo ""
         echo "Collaborators:"
         echo "  $collaborator_emails_csv"

--- a/snap-setup.sh
+++ b/snap-setup.sh
@@ -29,10 +29,6 @@ fail() {
 	exit 1
 }
 
-command_help_exists() {
-	"$CLI_TOOL" help "$1" >/dev/null 2>&1
-}
-
 validate_snap_name() {
 	local value="$1"
 
@@ -97,7 +93,13 @@ parse_args() {
 				;;
 			--collaborators)
 				[[ $# -ge 2 ]] || fail "--collaborators requires a value"
-                collaborator_emails_csv=$([[ -z "$collaborator_emails_csv" ]] && echo "$2" || echo "$collaborator_emails_csv,$2") # Append
+                if [[ -z "$collaborator_emails_csv" ]]; then
+                    # Init
+                    collaborator_emails_csv="$2"
+                else
+                    # Append
+                    collaborator_emails_csv="$collaborator_emails_csv,$2"
+                fi
 				shift 2
 				;;
 			--assume-yes)

--- a/snap-setup.sh
+++ b/snap-setup.sh
@@ -185,6 +185,7 @@ main() {
 
     register_snap
 
+    echo ""
     echo "Snap setup complete for '$snap_name'."
     echo "Please visit the snapcraft dashboard to add collaborators:"
     echo "  https://dashboard.snapcraft.io/snaps/$snap_name/collaboration/"

--- a/snap-setup.sh
+++ b/snap-setup.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CLI_TOOL="${CLI_TOOL:-snapcraft}"
+
+snap_name=""
+visibility=""
+collaborator_emails_csv=""
+assume_yes=false
+dry_run=false
+
+print_cmd() {
+	printf "+ "
+	printf "%q " "$@"
+	printf "\n"
+}
+
+sc_cmd() {
+	if [[ "$dry_run" == true ]]; then
+		print_cmd "$CLI_TOOL" "$@"
+	else
+		"$CLI_TOOL" "$@"
+	fi
+}
+
+fail() {
+	echo "Error: $1" >&2
+	exit 1
+}
+
+command_help_exists() {
+	"$CLI_TOOL" help "$1" >/dev/null 2>&1
+}
+
+validate_snap_name() {
+	local value="$1"
+
+	if [[ ! "$value" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+		fail "invalid snap name '$value'. Expected lowercase letters, digits, and single dashes only."
+	fi
+}
+
+usage() {
+	cat <<EOF
+Usage: $0 --snap <snap_name> --visibility <value> [options]
+
+Register a snap in the store and optionally set initial metadata.
+
+Required arguments:
+  --snap <snap_name>            Snap name to register.
+  --visibility <value>          Snap visibility: public or private
+
+Optional arguments:
+  --collaborators <csv>         Comma-separated collaborator email list, e.g. "a@example.com,b@example.com".
+  --assume-yes                  Skip confirmation prompt.
+  --dry-run                     Print commands without executing them.
+  -h, --help                    Show this help message and exit.
+
+Environment overrides:
+  CLI_TOOL                      Path to the CLI binary to use (default: snapcraft).
+
+Examples:
+  $0 --snap deepseek-r1 --visibility private --collaborators dev@example.com
+  $0 --snap deepseek-r1 --visibility public --collaborators "a@example.com,b@example.com"
+EOF
+}
+
+ask_yes_no() {
+	if [[ "$assume_yes" == true ]]; then
+		return 0
+	fi
+
+	read -r -p "$1 (y/N): " response
+	case "$response" in
+		[yY][eE][sS]|[yY])
+			return 0
+			;;
+		*)
+			return 1
+			;;
+	esac
+}
+
+parse_args() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--snap)
+				[[ $# -ge 2 ]] || fail "--snap requires a value"
+				snap_name="$2"
+				shift 2
+				;;
+			--visibility)
+				[[ $# -ge 2 ]] || fail "--visibility requires a value"
+				visibility="$2"
+				shift 2
+				;;
+			--collaborators)
+				[[ $# -ge 2 ]] || fail "--collaborators requires a value"
+                collaborator_emails_csv=$([[ -z "$collaborator_emails_csv" ]] && echo "$2" || echo "$collaborator_emails_csv,$2") # Append
+				shift 2
+				;;
+			--set-metadata-from)
+                [[ $# -ge 2 ]] || fail "--set-metadata-from requires a value"
+				metadata_source_file="$2"
+				shift 2
+				;;
+			--assume-yes)
+				assume_yes=true
+				shift
+				;;
+			--dry-run)
+				dry_run=true
+				shift
+				;;
+			-h|--help)
+				usage
+				exit 0
+				;;
+			*)
+				fail "unknown argument '$1'"
+				;;
+		esac
+	done
+}
+
+validate_inputs() {
+	[[ -n "$snap_name" ]] || fail "--snap is required"
+    [[ -n "$visibility" ]] || fail "--visibility is required"
+    [[ -n "$metadata_source_file" && ! -f "$metadata_source_file" ]] || fail "Cannot access metadata source file: $metadata_source_file"
+
+	validate_snap_name "$snap_name"
+
+	case "$visibility" in
+		public|private)
+			;;
+		*)
+			fail "invalid visibility '$visibility'. Expected 'public' or 'private'."
+			;;
+	esac
+}
+
+ensure_snapcraft_available() {
+	if ! command -v "$CLI_TOOL" >/dev/null 2>&1; then
+		fail "'$CLI_TOOL' was not found. Install snapcraft by running: 'sudo snap install snapcraft --classic'"
+	fi
+}
+
+ensure_snapcraft_logged_in() {
+	if [[ "$dry_run" == true ]]; then
+		echo "Dry run: skipping login status check."
+		return 0
+	fi
+
+	if ! "$CLI_TOOL" whoami >/dev/null 2>&1; then
+		fail "Snapcraft is not logged in. Run '$CLI_TOOL login' and retry."
+	fi
+}
+
+register_snap() {
+    local visibility_arg=""
+    if [[ "$visibility" == "private" ]]; then
+        visibility_arg="--private"
+    fi
+
+	echo "Registering snap '$snap_name' with visibility '$visibility'..."
+	local register_args=(register "$snap_name" "$visibility_arg" --yes)
+	sc_cmd "${register_args[@]}"
+}
+
+set_metadata(){
+    if [[ -z "${metadata_source_file:-}" ]]; then
+        echo "No metadata source file provided, skipping metadata upload."
+        return 0
+    fi
+
+    echo "Setting snap metadata from '$metadata_source_file'..."
+    sc_cmd "upload_metadata" "--force" "$metadata_source_file"
+}
+
+main() {
+	parse_args "$@"
+	validate_inputs
+
+	ensure_snapcraft_available
+	ensure_snapcraft_logged_in
+
+	echo ""
+	echo "The following setup will be applied:"
+	echo "  - Snap name: $snap_name"
+	echo "  - Visibility: $visibility"
+	echo "  - Snap metadata: $([[ -n "$metadata_source_file" ]] && echo "extracted from $metadata_source_file" || echo "unset")"
+	echo ""
+
+	if ! ask_yes_no "> Continue"; then
+		echo "Aborting."
+		exit 0
+	fi
+
+	register_snap
+    set_metadata
+
+	echo "Snap setup complete for '$snap_name'."
+
+    if [[ -n "$collaborator_emails_csv" ]]; then
+        echo "Please visit the snapcraft dashboard to add collaborators: https://dashboard.snapcraft.io/snaps/$snap_name/collaboration/"
+        echo ""
+        echo "Collaborators:"
+        echo "  $collaborator_emails_csv"
+        echo ""
+    fi
+}
+
+main "$@"
+
+


### PR DESCRIPTION
This script can be used to validate and register a snap name, while providing a quick link to the snapcraft dashboard. 

The dashboard can be used to further manager the registered name, including managing collaborators, a function that is only available in the web interface (see [this post](https://forum.snapcraft.io/t/adding-collaborators-from-command-line/41426)).