### PR TITLE
Fix broken smoke tests

### DIFF
--- a/smoke-tests.sh
+++ b/smoke-tests.sh
@@ -390,7 +390,7 @@ test_automatic_engine_selection() {
   log_section "Automatic engine selection test"
 
   log_info "Running: $snap_name use-engine --auto"
-  engine=$(sudo "$snap_name" use-engine --auto --assume-yes | grep -oP 'Selected engine: \K\S+')
+  engine=$("$snap_name" use-engine --auto --assume-yes | grep -oP 'Selected engine: \K\S+')
 
   log_info "Selected engine: $engine"
 

--- a/smoke-tests.sh
+++ b/smoke-tests.sh
@@ -115,9 +115,9 @@ check_for_curl() {
   fi
 }
 
-check_for_yq() {
-  if ! command -v yq &>/dev/null; then
-    exit_error "yq is required but not installed. Please install yq v4.x and try again."
+check_for_jq() {
+  if ! command -v jq &>/dev/null; then
+    exit_error "jq is not available. Please install it and try again."
   fi
 }
 
@@ -356,7 +356,7 @@ use_engine_with_retry() {
 
 get_curr_engine() {
   local snap_name="$1"
-  echo $("$snap_name" status --format=json 2>&1 | yq -p=json '.engine')
+  echo $("$snap_name" status --format=json | jq -r '.engine')
 }
 
 test_engine_switching() {
@@ -446,7 +446,7 @@ main() {
 # Validation
 check_root_privileges
 check_for_curl
-check_for_yq
+check_for_jq
 validate_arguments "$@"
 
 # Extract arguments

--- a/smoke-tests.sh
+++ b/smoke-tests.sh
@@ -157,8 +157,7 @@ test_endpoint() {
 
 test_chat_completion() {
   local base_url="$1"
-  local base_path="$2"
-  local model_name="$3"
+  local model_name="$2"
 
   log_info "Testing chat completion endpoint..."
 
@@ -189,7 +188,7 @@ EOF
 
   local api_response
   api_response=$(
-    curl -X POST "$base_url/$base_path/chat/completions" \
+    curl -X POST "$base_url/chat/completions" \
       -H "Content-Type: application/json" \
       --max-time "$CURL_TIMEOUT" \
       --retry 0 \
@@ -213,16 +212,15 @@ EOF
 
 run_api_tests() {
   local base_url="$1"
-  local base_path="$2"
-  local model_name="$3"
+  local model_name="$2"
 
   log_section "API Endpoint Tests"
 
   # Test models endpoint
-  test_endpoint "$base_url/$base_path/models" "List available models"
+  test_endpoint "$base_url/models" "List available models"
 
   # Test chat completion
-  test_chat_completion "$base_url" "$base_path" "$model_name"
+  test_chat_completion "$base_url" "$model_name"
 }
 
 # =============================================================================
@@ -423,9 +421,7 @@ main() {
   # Get server settings
   local server_port
   server_port=$("$snap_name" get http.port)
-  local base_path
-  base_path=$("$snap_name" get http.base-path)
-  local base_url="http://localhost:$server_port"
+  local base_url=$("$snap_name" status --format=json | jq -r .endpoints.openai )
   local model_name
   model_name=$("$snap_name" get model-name 2>/dev/null || true)
 
@@ -433,7 +429,7 @@ main() {
   check_port_listening "$server_port"
 
   # Run all test suites
-  run_api_tests "$base_url" "$base_path" "$model_name"
+  run_api_tests "$base_url" "$model_name"
   test_snap_installation "$snap_name"
   test_configuration_management "$snap_name"
   test_engine_listing "$snap_name"

--- a/smoke-tests.sh
+++ b/smoke-tests.sh
@@ -279,7 +279,7 @@ test_engine_listing() {
 
   log_info "Comparing available vs declared engines..."
 
-  mapfile -t avail_engines < <("$snap_name" list-engines | tail -n +2 | awk '{print $1}' | sort)
+  mapfile -t avail_engines < <("$snap_name" list-engines --format=json | yq -p=json -r '.engines[].name' | sort)
   echo -e "Available engines:\n${avail_engines[*]}"
 
   mapfile -t src_engines < <(find "/snap/$AI_SNAP_NAME/current/engines/" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort)

--- a/smoke-tests.sh
+++ b/smoke-tests.sh
@@ -279,7 +279,7 @@ test_engine_listing() {
 
   log_info "Comparing available vs declared engines..."
 
-  mapfile -t avail_engines < <("$snap_name" list-engines --format=json | yq -p=json -r '.engines[].name' | sort)
+  mapfile -t avail_engines < <("$snap_name" list-engines --format=json | jq -r '.engines[].name' | sort)
   echo -e "Available engines:\n${avail_engines[*]}"
 
   mapfile -t src_engines < <(find "/snap/$AI_SNAP_NAME/current/engines/" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort)

--- a/smoke-tests.sh
+++ b/smoke-tests.sh
@@ -254,7 +254,7 @@ test_configuration_management() {
   "$snap_name" get http.port
 
   log_info "Testing configuration change..."
-  "$snap_name" set http.port=9999
+  "$snap_name" set http.port=9999 --assume-yes
 
   # Verify config change persisted
   local port
@@ -265,7 +265,7 @@ test_configuration_management() {
   log_info "✓ Configuration change persisted successfully"
 
   log_info "Reverting configuration change..."
-  "$snap_name" set http.port="$default_port"
+  "$snap_name" set http.port="$default_port" --assume-yes
 }
 
 # =============================================================================
@@ -390,8 +390,8 @@ test_automatic_engine_selection() {
   log_section "Automatic engine selection test"
 
   log_info "Running: $snap_name use-engine --auto"
-  "$snap_name" use-engine --auto
-  engine=$(sudo "$snap_name" use-engine --auto 2>&1 | grep -oP 'Selected engine: \K\S+')
+  "$snap_name" use-engine --auto --assume-yes
+  engine=$(sudo "$snap_name" use-engine --auto --assume-yes 2>&1 | grep -oP 'Selected engine: \K\S+')
 
   log_info "Selected engine: $engine"
 

--- a/smoke-tests.sh
+++ b/smoke-tests.sh
@@ -356,7 +356,7 @@ use_engine_with_retry() {
 
 get_curr_engine() {
   local snap_name="$1"
-  echo $("$snap_name" status --format=json | jq -r '.engine')
+  "$snap_name" status --format=json | jq -r '.engine'
 }
 
 test_engine_switching() {
@@ -390,8 +390,7 @@ test_automatic_engine_selection() {
   log_section "Automatic engine selection test"
 
   log_info "Running: $snap_name use-engine --auto"
-  "$snap_name" use-engine --auto --assume-yes
-  engine=$(sudo "$snap_name" use-engine --auto --assume-yes 2>&1 | grep -oP 'Selected engine: \K\S+')
+  engine=$(sudo "$snap_name" use-engine --auto --assume-yes | grep -oP 'Selected engine: \K\S+')
 
   log_info "Selected engine: $engine"
 
@@ -421,7 +420,7 @@ main() {
   # Get server settings
   local server_port
   server_port=$("$snap_name" get http.port)
-  local base_url=$("$snap_name" status --format=json | jq -r .endpoints.openai )
+  local base_url=$("$snap_name" status --format=json | jq -r '.endpoints.openai' )
   local model_name
   model_name=$("$snap_name" get model-name 2>/dev/null || true)
 


### PR DESCRIPTION
- Drop deprecated base-url config query
- Use json serialization to avoid getting newly added asterisk for active engine
- Drop yq usage and use newly added json format
- Assume yes for new prompts

```console
$ sudo ./dev/smoke-tests.sh gemma4 cpu-e2b

=== Starting Smoke Tests ===
[INFO] Running tests against snap: gemma4
[INFO] Selected engine: cpu-e2b
[INFO] Port 8336 is listening

=== API Endpoint Tests ===
[INFO] Testing List available models: http://localhost:8336/v1/models
[INFO] ✓ List available models: OK
[INFO] Testing chat completion endpoint...
Chat payload:
{
  "model": "",
  "messages": [
    {
      "role": "developer",
      "content": "You are a helpful assistant."
    },
    {
      "role": "user",
      "content": "Hello!"
    }
  ],
  "temperature": 0,
  "max_tokens": 5
}
[INFO] ✓ Chat completion: OK

=== Snap Installation Test ===
[INFO] Checking snap installation...
Name    Version      Rev  Tracking  Publisher  Notes
gemma4  e4b+a740bad  x1   -         -          -

=== Configuration Management Tests ===
[INFO] Checking all configs (snap get)...
{
        "a": {
                "Z": 3
        },
        "cache": {
                "active-engine": "cpu-e2b"
        },
        "config": {
                "engine": {
                        "sleep-idle-seconds": 600
                },
                "package": {
                        "http": {
                                "host": "127.0.0.1",
                                "port": 8336
                        },
                        "verbose": false,
                        "webui": {
                                "http": {
                                        "host": "127.0.0.1",
                                        "port": 8337
                                }
                        }
                },
                "user": {
                        "http": {
                                "host": "localhost",
                                "port": 8336
                        },
                        "webui": {
                                "http": {
                                        "host": "0.0.0.0"
                                }
                        }
                }
        },
        "x": 1
}
[INFO] Checking all configs (snap command)...
http.host: localhost
http.port: 8336
sleep-idle-seconds: 600
verbose: false
webui.http.host: 0.0.0.0
webui.http.port: 8337
[INFO] Getting config subset...
[INFO] Getting specific config...
8336
[INFO] Testing configuration change...
[INFO] ✓ Configuration change persisted successfully
[INFO] Reverting configuration change...

=== Engine Listing Tests ===
[INFO] Comparing available vs declared engines...
Available engines:
amd-gpu-26b amd-gpu-e2b amd-gpu-e4b cpu-26b cpu-e2b cpu-e4b nvidia-gpu-26b nvidia-gpu-e2b nvidia-gpu-e4b
Declared engines:
amd-gpu-26b amd-gpu-e2b amd-gpu-e4b cpu-26b cpu-e2b cpu-e4b nvidia-gpu-26b nvidia-gpu-e2b nvidia-gpu-e4b
[INFO] ✓ Engine lists match successfully
[INFO] Querying individual engines...
[INFO] Querying engine: amd-gpu-26b
[INFO] Querying engine: amd-gpu-e2b
[INFO] Querying engine: amd-gpu-e4b
[INFO] Querying engine: cpu-26b
[INFO] Querying engine: cpu-e2b
[INFO] Querying engine: cpu-e4b
[INFO] Querying engine: nvidia-gpu-26b
[INFO] Querying engine: nvidia-gpu-e2b
[INFO] Querying engine: nvidia-gpu-e4b

=== Automatic engine selection test ===
[INFO] Running: gemma4 use-engine --auto
Evaluating engines for optimal hardware compatibility:
✘ amd-gpu-26b: not compatible
✘ amd-gpu-e2b: not compatible
✘ amd-gpu-e4b: not compatible
• cpu-26b: devel, score=12
• cpu-e2b: devel, score=12
✔ cpu-e4b: compatible, score=12
• nvidia-gpu-26b: devel, score=92
• nvidia-gpu-e2b: devel, score=92
✔ nvidia-gpu-e4b: compatible, score=92
Selected engine: nvidia-gpu-e4b
Engine changed to "nvidia-gpu-e4b".
[INFO] Selected engine: nvidia-gpu-e4b
Stopped.
Started.

=== Engine Switching Tests ===
[INFO] Checking current engine status...
engine: nvidia-gpu-e4b
services:
    server: active
    server-webui: active
endpoints:
    openai: http://localhost:8336/v1
    webui: http://localhost:8337/
model:
    name: gemma4-e4b-q4-k-m
[INFO] Showing current engine...
name: nvidia-gpu-e4b
description: CUDA-optimized E4B model for NVIDIA GPUs
vendor: Canonical Ltd
grade: stable
devices:
    anyof:
        - type: cpu
          architecture: amd64
        - type: cpu
          architecture: arm64
          compatibility-issues:
            - architecture not arm64
    allof:
        - type: gpu
          vendor-id: "0x10DE"
memory: 8G
disk-space: 8G
components:
    - llamacpp-cuda
    - model-e4b-q4-k-m-gguf
    - mmproj-e4b-q8-0-gguf
configurations:
    sleep-idle-seconds: 600
score: 92
compatible: true
[INFO] Testing engine switch with retry logic...
[INFO] Switching to engine: cpu-e2b
[INFO] Attempt 1/60: Switching to engine cpu-e2b
[INFO] ✓ Successfully switched to engine: cpu-e2b
[INFO] Verifying engine switch via status command...
[INFO] ✓ Engine switch verified via status command

=== All Smoke Tests Completed Successfully! ===
```