### PR TITLE
Improve repository setup script

### DIFF
--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -335,6 +335,26 @@ add_workflow_trigger_labels() {
     gh_cmd label create --force trigger-tests --repo "${repo_owner}/${repo_name}" --color 666666 --description "Trigger test pipeline on last build, if not present triggers also build"
 }
 
+add_github_action_variables() {
+    echo "Creating GitHub Actions variables..."
+
+    gh_api_json POST "/repos/${repo_owner}/${repo_name}/actions/variables" "$(cat <<EOF
+{
+    "name": "PR_BUILD_TRIGGER_LABEL",
+    "value": "trigger-build"
+}
+EOF
+)"
+
+    gh_api_json POST "/repos/${repo_owner}/${repo_name}/actions/variables" "$(cat <<EOF
+{
+    "name": "PR_TEST_TRIGGER_LABEL",
+    "value": "trigger-tests"
+}
+EOF
+)"
+}
+
 main() {
     parse_args "$@"
 
@@ -391,6 +411,7 @@ main() {
     ensure_repo_exists
     setup_repository_settings
     add_workflow_trigger_labels
+    add_github_action_variables
     add_team_permissions
     add_branch_rules
 

--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -339,21 +339,30 @@ add_workflow_trigger_labels() {
 add_github_action_variables() {
     echo "Creating GitHub Actions variables..."
 
-    gh_api_json POST "/repos/${repo_owner}/${repo_name}/actions/variables" "$(cat <<EOF
-{
-    "name": "PR_BUILD_TRIGGER_LABEL",
-    "value": "trigger-build"
-}
-EOF
-)"
+    set_github_action_variable() {
+        local name="$1"
+        local value="$2"
 
-    gh_api_json POST "/repos/${repo_owner}/${repo_name}/actions/variables" "$(cat <<EOF
+        # Upsert behavior: update when the variable exists, otherwise create it.
+        if ! gh_api_json PATCH "/repos/${repo_owner}/${repo_name}/actions/variables/${name}" "$(cat <<EOF
 {
-    "name": "PR_TEST_TRIGGER_LABEL",
-    "value": "trigger-tests"
+    "name": "${name}",
+    "value": "${value}"
+}
+EOF
+)"; then
+            gh_api_json POST "/repos/${repo_owner}/${repo_name}/actions/variables" "$(cat <<EOF
+{
+    "name": "${name}",
+    "value": "${value}"
 }
 EOF
 )"
+        fi
+    }
+
+    set_github_action_variable "PR_BUILD_TRIGGER_LABEL" "trigger-build"
+    set_github_action_variable "PR_TEST_TRIGGER_LABEL" "trigger-tests"
 }
 
 main() {

--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -260,7 +260,8 @@ ensure_repo_exists() {
     if [[ "$modify_existing_repo" == true ]]; then
         # Validate repo existence
         echo "Verifying repository ${repo_owner}/${repo_name} exists for modification..."
-        if ! gh_cmd repo view "${repo_owner}/${repo_name}"; then
+        # Use a silent API probe instead of `gh repo view` to avoid pager/full-screen output.
+        if ! gh_api_json GET "/repos/${repo_owner}/${repo_name}" ""; then
             fail "Repository '${repo_owner}/${repo_name}' not found or inaccessible. Cannot modify non-existing repository."
         fi
     else


### PR DESCRIPTION
This PR adds a missing step in the repository setup script to add GitHub **Action variables** to the repository, while also improving the user experience by eliminating a **pager** when a repository existence is being validated