### PR TITLE
Fix smoke test retries

### DIFF
--- a/.github/actions/smoke-test/action.yaml
+++ b/.github/actions/smoke-test/action.yaml
@@ -7,32 +7,15 @@ inputs:
   engine:
     description: Engine to validate during smoke tests
     required: true
-  curl-timeout:
-    description: CURL timeout in seconds
-    required: false
-    default: "10"
-  max-retries:
-    description: Max retries for retry logic in smoke tests
-    required: false
-    default: "50"
-  retry-delay:
-    description: Delay between retries in seconds
-    required: false
-    default: "10"
 
 runs:
   using: composite
   steps:
     - name: Run smoke tests
       shell: bash
-      env:
-        CURL_TIMEOUT: ${{ inputs.curl-timeout }}
-        MAX_RETRIES: ${{ inputs.max-retries }}
-        RETRY_DELAY: ${{ inputs.retry-delay }}
       run: |
         set -euo pipefail
 
         action_repo_root="$(realpath "$GITHUB_ACTION_PATH/../../..")"
 
-        # -E tells sudo to preserve the caller's environment variables when running the command
-        sudo -E "$action_repo_root/smoke-test.sh" "${{ inputs.snap-name }}" "${{ inputs.engine }}"
+        sudo "$action_repo_root/smoke-test.sh" "${{ inputs.snap-name }}" "${{ inputs.engine }}"

--- a/.github/actions/smoke-test/action.yaml
+++ b/.github/actions/smoke-test/action.yaml
@@ -18,4 +18,5 @@ runs:
 
         action_repo_root="$(realpath "$GITHUB_ACTION_PATH/../../..")"
 
-        sudo -E "$action_repo_root/smoke-test.sh" "${{ inputs.snap-name }}" "${{ inputs.engine }}"
+        sudo --preserve-env=GITHUB_ACTIONS \
+          "$action_repo_root/smoke-test.sh" "${{ inputs.snap-name }}" "${{ inputs.engine }}"

--- a/.github/actions/smoke-test/action.yaml
+++ b/.github/actions/smoke-test/action.yaml
@@ -18,4 +18,4 @@ runs:
 
         action_repo_root="$(realpath "$GITHUB_ACTION_PATH/../../..")"
 
-        sudo "$action_repo_root/smoke-test.sh" "${{ inputs.snap-name }}" "${{ inputs.engine }}"
+        sudo -E "$action_repo_root/smoke-test.sh" "${{ inputs.snap-name }}" "${{ inputs.engine }}"

--- a/.github/workflows/reuse-cicd.yaml
+++ b/.github/workflows/reuse-cicd.yaml
@@ -53,21 +53,21 @@ on:
 
 
 jobs:
-  # build-edge:
-  #   uses: ./.github/workflows/build-publish-snap.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       runner: ${{ fromJSON(inputs.build-runner) }}
-  #   with:
-  #     runner: "${{ toJSON(matrix.runner) }}"
-  #     init-build-script: ${{ inputs.build-init-script }}
-  #     publish-channel: ${{ inputs.store-track }}/edge
-  #   secrets:
-  #     store-credentials: ${{ secrets.store-credentials }} 
+  build-edge:
+    uses: ./.github/workflows/build-publish-snap.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJSON(inputs.build-runner) }}
+    with:
+      runner: "${{ toJSON(matrix.runner) }}"
+      init-build-script: ${{ inputs.build-init-script }}
+      publish-channel: ${{ inputs.store-track }}/edge
+    secrets:
+      store-credentials: ${{ secrets.store-credentials }} 
 
   smoke-test:
-    # needs: [build-edge]
+    needs: [build-edge]
     strategy:
       fail-fast: false
       matrix:
@@ -85,7 +85,7 @@ jobs:
           sudo snap install ${{ inputs.snap-name }} --channel ${{ inputs.store-track }}/edge
   
       - name: Run smoke tests
-        uses: canonical/inference-snaps-dev/.github/actions/smoke-test@extend-smoke-test-config # temp. change to v2
+        uses: canonical/inference-snaps-dev/.github/actions/smoke-test@v2
         with:
           snap-name: ${{ inputs.snap-name }}
           engine: ${{ inputs.smoke-test-engine }}

--- a/.github/workflows/reuse-cicd.yaml
+++ b/.github/workflows/reuse-cicd.yaml
@@ -9,7 +9,7 @@ on:
           
           The input should be a JSON array of runner configurations. For example:
           - '[["self-hosted", "amd64"], ["self-hosted", "arm64"]]'
-          - '["ubuntu-latest", "ubuntu-latest"]' for single label per architecture
+          - '["ubuntu-24.04", "ubuntu-24.04-arm"]' for single label per architecture
           
           The input must be quoted and passed as a string.
         required: true
@@ -24,6 +24,17 @@ on:
         description: Name of the snap to build and publish
         required: true
         type: string
+
+      smoke-test-runner:
+        description: |
+          JSON array containing runner configurations for each architecture for smoke testing.  
+          The input should be a JSON array of runner configurations. For example:
+          - '[["self-hosted", "amd64"], ["self-hosted", "arm64"]]'
+          - '["ubuntu-24.04", "ubuntu-24.04-arm"]' for single label per architecture
+          The input must be quoted and passed as a string.
+        required: false
+        type: string
+        default: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
 
       smoke-test-engine:
         description: Engine to validate during smoke tests
@@ -42,27 +53,25 @@ on:
 
 
 jobs:
-  build-edge:
-    uses: ./.github/workflows/build-publish-snap.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: ${{ fromJSON(inputs.build-runner) }}
-    with:
-      runner: "${{ toJSON(matrix.runner) }}"
-      init-build-script: ${{ inputs.build-init-script }}
-      publish-channel: ${{ inputs.store-track }}/edge
-    secrets:
-      store-credentials: ${{ secrets.store-credentials }} 
+  # build-edge:
+  #   uses: ./.github/workflows/build-publish-snap.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       runner: ${{ fromJSON(inputs.build-runner) }}
+  #   with:
+  #     runner: "${{ toJSON(matrix.runner) }}"
+  #     init-build-script: ${{ inputs.build-init-script }}
+  #     publish-channel: ${{ inputs.store-track }}/edge
+  #   secrets:
+  #     store-credentials: ${{ secrets.store-credentials }} 
 
   smoke-test:
-    needs: [build-edge]
+    # needs: [build-edge]
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          - ubuntu-24.04
-          - ubuntu-24.04-arm
+        runner: ${{ fromJSON(inputs.smoke-test-runner) }}
     runs-on: ${{ matrix.runner }}
     
     steps:
@@ -80,6 +89,7 @@ jobs:
         with:
           snap-name: ${{ inputs.snap-name }}
           engine: ${{ inputs.smoke-test-engine }}
+          curl-timeout: "60"
   
   promote-beta:
     needs: [smoke-test]

--- a/.github/workflows/reuse-cicd.yaml
+++ b/.github/workflows/reuse-cicd.yaml
@@ -85,11 +85,10 @@ jobs:
           sudo snap install ${{ inputs.snap-name }} --channel ${{ inputs.store-track }}/edge
   
       - name: Run smoke tests
-        uses: canonical/inference-snaps-dev/.github/actions/smoke-test@v2
+        uses: canonical/inference-snaps-dev/.github/actions/smoke-test@extend-smoke-test-config # temp. change to v2
         with:
           snap-name: ${{ inputs.snap-name }}
           engine: ${{ inputs.smoke-test-engine }}
-          curl-timeout: "60"
   
   promote-beta:
     needs: [smoke-test]

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -97,10 +97,10 @@ exit_error() {
 
 usage() {
   echo "Usage: $0 <inference-snap-name> <engine>"
-  echo "Runs smoke tests for one specified engine against an inference snap."
+  echo "Runs smoke tests for a specific engine against an inference snap."
   echo
   echo "Example:"
-  echo "./$(basename "$0") deepseek-r1 cpu-tiny"
+  echo "./$(basename "$0") gemma4 cpu"
 }
 
 # =============================================================================
@@ -342,7 +342,7 @@ test_engine_listing() {
   mapfile -t avail_engines < <("$snap_name" list-engines --format=json | jq -r '.engines[].name' | sort)
   echo -e "Available engines:\n${avail_engines[*]}"
 
-  mapfile -t src_engines < <(find "/snap/$AI_SNAP_NAME/current/engines/" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort)
+  mapfile -t src_engines < <(find "/snap/$snap_name/current/engines/" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort)
   echo -e "Declared engines:\n${src_engines[*]}"
 
   if [[ ${#avail_engines[@]} -ne ${#src_engines[@]} ]]; then
@@ -452,8 +452,8 @@ check_for_jq
 validate_arguments "$@"
 
 # Extract arguments
-AI_SNAP_NAME="$1"
-MODEL_ENGINE="$2"
+SNAP_NAME="$1"
+ENGINE="$2"
 
 # Run main function
-main "$AI_SNAP_NAME" "$MODEL_ENGINE"
+main "$SNAP_NAME" "$ENGINE"

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -150,13 +150,13 @@ check_port_listening() {
 # =============================================================================
 
 test_endpoint_models() {
-  local base_url="$1"
   local timeout_seconds=300  # 5 minutes
   local retry_delay=10
   local connection_timeout=60
   local start_time
   start_time=$(date +%s)
 
+  local base_url=$("$snap_name" status --format=json | jq -r '.endpoints.openai' )
   local endpoint="$base_url/models"
 
   log_info "Testing OpenAI models endpoint."
@@ -173,6 +173,8 @@ test_endpoint_models() {
       return 0
     fi
 
+    # TODO: warn or error if the model name doesn't match the name in status
+
     current_time=$(date +%s)
     elapsed=$((current_time - start_time))
 
@@ -186,12 +188,13 @@ test_endpoint_models() {
 }
 
 test_endpoint_chat_completion() {
-  local base_url="$1"
-  local model_name="$2"
   local max_retries=5
   local retry_delay=60
   local connection_timeout=60
   local attempt=1
+
+  local base_url=$("$snap_name" status --format=json | jq -r '.endpoints.openai' )
+  local model_name=$("$snap_name" status --format=json | jq -r '.model.name')
   local endpoint="$base_url/chat/completions"
 
   log_info "Testing OpenAI chat completions endpoints."
@@ -261,13 +264,10 @@ EOF
 }
 
 run_api_tests() {
-  local base_url="$1"
-  local model_name="$2"
-
   log_section "API Endpoint Tests"
 
-  test_endpoint_models "$base_url"
-  test_endpoint_chat_completion "$base_url" "$model_name"
+  test_endpoint_models
+  test_endpoint_chat_completion
 }
 
 # =============================================================================
@@ -286,19 +286,19 @@ test_configuration_management() {
   local snap_name="$1"
   local default_port
 
-  log_section "Configuration Management Tests"
+  log_section "Configuration Tests"
 
-  log_info "Checking all configs (snap get $snap_name)..."
+  log_info "Print internal configs (snap get $snap_name)..."
   snap get "$snap_name" -d
 
-  log_info "Checking all configs ($snap_name get)..."
+  log_info "Print configs ($snap_name get)..."
   "$snap_name" get
 
   log_info "Getting specific config..."
   default_port=$("$snap_name" get http.port)
   echo "$default_port"
 
-  log_info "Testing configuration change..."
+  log_info "Testing config change..."
   "$snap_name" set http.port=9999 --assume-yes
 
   # Verify config change persisted
@@ -307,9 +307,9 @@ test_configuration_management() {
   if (("$port" != 9999)); then
     exit_error "Config change did not persist."
   fi
-  log_info "✓ Configuration change persisted successfully"
+  log_info "✓ Config change persisted successfully"
 
-  log_info "Reverting configuration change..."
+  log_info "Reverting config change..."
   "$snap_name" set http.port="$default_port" --assume-yes
 }
 
@@ -410,14 +410,9 @@ main() {
   log_info "Running tests against snap: $snap_name"
   log_info "Selected engine: $target_engine"
 
-  # Get server settings
+  # Pre-flight checks
   local server_port
   server_port=$("$snap_name" get http.port)
-  local base_url=$("$snap_name" status --format=json | jq -r '.endpoints.openai' )
-  local model_name
-  model_name=$("$snap_name" status --format=json | jq -r '.model.name')
-
-  # Pre-flight checks
   check_port_listening "$server_port"
 
   # Run all test suites
@@ -426,7 +421,7 @@ main() {
   test_engine_listing "$snap_name"
   test_automatic_engine_selection "$snap_name"
   test_engine_switching "$snap_name" "$target_engine"
-  run_api_tests "$base_url" "$model_name"
+  run_api_tests
 
   log_section "All Smoke Tests Completed Successfully!"
 }

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -75,8 +75,23 @@ log_section() {
   echo -e "\n${BLUE}=== $1 ===${NC}"
 }
 
+log_debugging_info() {
+  log_section "Snap logs"
+  snap logs -n all "$snap_name"
+  
+  log_section "Machine info"
+  "$snap_name" show-machine
+}
+
 exit_error() {
   log_error "$1"
+
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::group:: Debugging Information"
+    log_debugging_info
+    echo "::endgroup::"
+  fi
+
   exit 1
 }
 
@@ -182,7 +197,7 @@ test_endpoint_models() {
       log_warning "Endpoint failed; retrying in ${retry_delay}s"
       sleep "$retry_delay"
     else
-      exit_error "✗ $endpoint: Fails after $timeout_seconds seconds"
+      exit_error "✗ $endpoint: Failed after $timeout_seconds seconds"
     fi
   done
 }
@@ -259,7 +274,7 @@ EOF
     ((attempt++))
   done
 
-  exit_error "✗ $endpoint: Fail after $max_retries attempts"
+  exit_error "✗ $endpoint: Failed after $max_retries attempts"
 
 }
 

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -48,11 +48,6 @@ trap 'error_handler ${LINENO} ${BASH_LINENO[0]} "$BASH_COMMAND" "${FUNCNAME[1]}"
 # CONFIGURATION AND GLOBALS
 # =============================================================================
 
-# Configuration defaults (can be overridden by environment variables)
-: "${CURL_TIMEOUT:=10}"
-: "${MAX_RETRIES:=50}"
-: "${RETRY_DELAY:=10}"
-
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -89,13 +84,8 @@ usage() {
   echo "Usage: $0 <inference-snap-name> <engine>"
   echo "Runs smoke tests for one specified engine against an inference snap."
   echo
-  echo "Environment variables (optional overrides):"
-  echo "  CURL_TIMEOUT"
-  echo "  MAX_RETRIES"
-  echo "  RETRY_DELAY"
-  echo
   echo "Example:"
-  echo "CURL_TIMEOUT=40 MAX_RETRIES=10 ./$(basename "$0") deepseek-r1 cpu-tiny"
+  echo "./$(basename "$0") deepseek-r1 cpu-tiny"
 }
 
 # =============================================================================
@@ -129,70 +119,82 @@ validate_arguments() {
 
 check_port_listening() {
   local port="$1"
-  local max_retries="$MAX_RETRIES"
-  local retry_delay="$RETRY_DELAY"
-  local attempt=1
+  local timeout_seconds=300
+  local retry_delay=10
+  local start_time
+  start_time=$(date +%s)
 
-  while [[ $attempt -le $max_retries ]]; do
-    log_info "Attempt $attempt/$max_retries: Checking whether port $port is listening"
+  while true; do
+    local current_time
+    current_time=$(date +%s)
+    local elapsed=$((current_time - start_time))
+
+    log_info "Checking whether port $port is listening (${elapsed}/${timeout_seconds}s)"
 
     if ss -tuln | grep -q ":$port "; then
-      log_info "Port $port is listening"
+      log_info "✓ Port $port is listening"
       return 0
     fi
 
-    if [[ $attempt -lt $max_retries ]]; then
-      log_warning "Port $port is not listening yet; retrying in ${retry_delay}s"
+    if [[ $elapsed -lt $timeout_seconds ]]; then
+      log_warning "Port $port not listening; retrying in ${retry_delay}s"
       sleep "$retry_delay"
+    else
+      exit_error "✗ Time out after ${timeout_seconds}s waiting for port $port to listen."
     fi
-
-    ((attempt++))
   done
-
-  exit_error "Port $port is not listening after $max_retries attempts. Is the snap running?"
 }
 
 # =============================================================================
 # HTTP API TESTING FUNCTIONS
 # =============================================================================
 
-test_endpoint() {
-  local endpoint="$1"
-  local description="$2"
-  local max_retries="$MAX_RETRIES"
-  local retry_delay="$RETRY_DELAY"
-  local attempt=1
+test_endpoint_models() {
+  local base_url="$1"
+  local timeout_seconds=300  # 5 minutes
+  local retry_delay=10
+  local connection_timeout=60
+  local start_time
+  start_time=$(date +%s)
 
-  log_info "Testing $description: $endpoint"
+  local endpoint="$base_url/models"
 
-  while [[ $attempt -le $max_retries ]]; do
-    log_info "Attempt $attempt/$max_retries: $description"
+  log_info "Testing OpenAI models endpoint."
 
-    if curl --retry 0 --fail-with-body --connect-timeout "$CURL_TIMEOUT" "$endpoint"; then
-      echo # Add a newline after the curl output
-      log_info "✓ $description: Pass"
+  while true; do
+    local current_time
+    current_time=$(date +%s)
+    local elapsed=$((current_time - start_time))
+
+    log_info "Checking $endpoint ($elapsed/${timeout_seconds}s)"
+
+    if curl --retry 0 --fail-with-body --write-out '\n' --connect-timeout $connection_timeout "$endpoint"; then
+      log_info "✓ $endpoint: Pass"
       return 0
     fi
 
-    if [[ $attempt -lt $max_retries ]]; then
-      log_warning "$description failed; retrying in ${retry_delay}s"
+    current_time=$(date +%s)
+    elapsed=$((current_time - start_time))
+
+    if [[ $elapsed -lt $timeout_seconds ]]; then
+      log_warning "Endpoint failed; retrying in ${retry_delay}s"
       sleep "$retry_delay"
+    else
+      exit_error "✗ $endpoint: Fails after $timeout_seconds seconds"
     fi
-
-    ((attempt++))
   done
-
-  exit_error "✗ $description: Fail after $max_retries attempts"
 }
 
-test_chat_completion() {
+test_endpoint_chat_completion() {
   local base_url="$1"
   local model_name="$2"
-  local max_retries=3
-  local retry_delay=20
+  local max_retries=5
+  local retry_delay=60
+  local connection_timeout=60
   local attempt=1
+  local endpoint="$base_url/chat/completions"
 
-  log_info "Testing chat completion endpoint..."
+  log_info "Testing OpenAI chat completions endpoints."
 
   local system_message="You are a helpful assistant."
   local prompt="Hello!"
@@ -213,24 +215,24 @@ test_chat_completion() {
 EOF
   )
 
-  echo -e "Chat payload:\n$json_body"
-
   local compact_json_body
   compact_json_body=$(echo "$json_body" | jq -c .)
 
   local api_response
   while [[ $attempt -le $max_retries ]]; do
-    log_info "Attempt $attempt/$max_retries: Chat completion"
+    log_info "Checking $endpoint ($attempt/$max_retries)"
 
     set +e
     set -x # log the curl command for debugging
     api_response=$(
-      curl -X POST "$base_url/chat/completions" \
+      curl -X POST "$endpoint" \
         -H "Content-Type: application/json" \
-        --max-time "$CURL_TIMEOUT" \
-        --retry 0 \
         -d "$compact_json_body" \
+        --connect-timeout $connection_timeout \
+        --max-time 600 \
+        --retry 0 \
         --fail-with-body \
+        --write-out '\n' \
         2>/dev/null
     )
     set +x
@@ -242,7 +244,7 @@ EOF
         exit_error "Empty response from server"
       fi
 
-      log_info "✓ Chat completion: OK"
+      log_info "✓ $endpoint: Pass"
       return 0
     fi
 
@@ -254,7 +256,7 @@ EOF
     ((attempt++))
   done
 
-  exit_error "Chat completion failed after $max_retries attempts (may indicate service issues)"
+  exit_error "✗ $endpoint: Fail after $max_retries attempts"
 
 }
 
@@ -264,11 +266,8 @@ run_api_tests() {
 
   log_section "API Endpoint Tests"
 
-  # Test models endpoint
-  test_endpoint "$base_url/models" "List available models"
-
-  # Test chat completion
-  test_chat_completion "$base_url" "$model_name"
+  test_endpoint_models "$base_url"
+  test_endpoint_chat_completion "$base_url" "$model_name"
 }
 
 # =============================================================================
@@ -289,17 +288,15 @@ test_configuration_management() {
 
   log_section "Configuration Management Tests"
 
-  log_info "Checking all configs (snap get)..."
+  log_info "Checking all configs (snap get $snap_name)..."
   snap get "$snap_name" -d
 
-  log_info "Checking all configs (snap command)..."
+  log_info "Checking all configs ($snap_name get)..."
   "$snap_name" get
 
-  log_info "Getting config subset..."
-  default_port=$("$snap_name" get http.port)
-
   log_info "Getting specific config..."
-  "$snap_name" get http.port
+  default_port=$("$snap_name" get http.port)
+  echo "$default_port"
 
   log_info "Testing configuration change..."
   "$snap_name" set http.port=9999 --assume-yes
@@ -351,17 +348,6 @@ test_engine_listing() {
   done
 }
 
-use_engine_with_retry() {
-  local snap_name="$1"
-  local engine="$2"
-
-  log_info "Switching to engine: $engine"
-
-  "$snap_name" use-engine "$engine" --assume-yes
-  
-  log_info "✓ Successfully switched to engine: $engine"
-}
-
 get_curr_engine() {
   local snap_name="$1"
   "$snap_name" status --format=json | jq -r '.engine'
@@ -373,14 +359,14 @@ test_engine_switching() {
 
   log_section "Engine Switching Tests"
 
-  log_info "Checking current engine status..."
+  log_info "Checking status..."
   "$snap_name" status
 
   log_info "Showing current engine..."
   "$snap_name" show-engine
 
-  log_info "Testing engine switch with retry logic..."
-  if ! use_engine_with_retry "$snap_name" "$target_engine"; then
+  log_info "Testing engine switch..."
+  if ! "$snap_name" use-engine "$target_engine" --assume-yes; then
     exit_error "Failed to switch to engine: $target_engine"
   fi
 
@@ -395,7 +381,7 @@ test_engine_switching() {
 
 test_automatic_engine_selection() {
   local snap_name="$1"
-  log_section "Automatic engine selection test"
+  log_section "Automatic Engine Selection Test"
 
   log_info "Running: $snap_name use-engine --auto"
   engine=$("$snap_name" use-engine --auto --assume-yes | grep -oP 'Selected engine: \K\S+')
@@ -410,7 +396,6 @@ test_automatic_engine_selection() {
   if [[ "$check" != "$engine" ]]; then
     exit_error "Automatic engine selection failed: status shows $check but expected $engine"
   fi
-
 }
 
 # =============================================================================
@@ -436,12 +421,12 @@ main() {
   check_port_listening "$server_port"
 
   # Run all test suites
-  run_api_tests "$base_url" "$model_name"
   test_snap_installation "$snap_name"
   test_configuration_management "$snap_name"
   test_engine_listing "$snap_name"
   test_automatic_engine_selection "$snap_name"
   test_engine_switching "$snap_name" "$target_engine"
+  run_api_tests "$base_url" "$model_name"
 
   log_section "All Smoke Tests Completed Successfully!"
 }


### PR DESCRIPTION
Drop reused retry inputs for different purposes. The same timeout and delay cannot be applied to port checking, models and chat APIs. In particular, chat requires care to account for time to first token and resource retention on cancelled tries. 

Fix base URL query so it does not break when switching engines (e.g. base paths differ when switching from intel to non intel engine).

Make test runners configurable, for larger snaps.


Test runs:
- [x] https://github.com/canonical/qwen3.6-snap/actions/runs/27547868106
- [x] https://github.com/canonical/qwen3-coder-snap/actions/runs/27553569467
- [x] https://github.com/canonical/gemma4-snap/actions/runs/27538582620
- [x] https://github.com/canonical/nemotron-3-nano-omni-snap/actions/runs/27539571928
- [x] https://github.com/canonical/gemma3-snap/actions/runs/27551281245
