### PR TITLE
Add shared renovate configuration for inference snaps

### DIFF
--- a/renovate/default.jsonc
+++ b/renovate/default.jsonc
@@ -1,6 +1,4 @@
 {
-  // Renovate configuration for Canonical inference snaps
-  // Shared across gemma4-snap, nemotron-3-nano-snap, and other inference snap projects
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"

--- a/renovate/renovate.json5
+++ b/renovate/renovate.json5
@@ -1,0 +1,67 @@
+{
+  // Renovate configuration for Canonical inference snaps
+  // Shared across gemma4-snap, nemotron-3-nano-snap, and other inference snap projects
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "git-submodules": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Automerge inference-snaps-dev update PRs",
+      "matchManagers": [
+        "git-submodules"
+      ],
+      "matchDepNames": [
+        "dev"
+      ],
+      "commitBody": "[skip ci]",
+      "automerge": true,
+      "automergeType": "pr",
+      "ignoreTests": true
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update inference-snaps-cli",
+      "fileMatch": [
+        "^snap/snapcraft\\.yaml$"
+      ],
+      "matchStrings": [
+        "https://github\\.com/canonical/inference-snaps-cli/releases/download/(?<currentValue>v[^/]+)/inference-snaps-cli"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "canonical/inference-snaps-cli",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update inference-snaps-webui",
+      "fileMatch": [
+        "^snap/snapcraft\\.yaml$"
+      ],
+      "matchStrings": [
+        "https://github\\.com/canonical/inference-snaps-webui/releases/download/(?<currentValue>v[^/]+)/inference-snaps-webui"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "canonical/inference-snaps-webui",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update llama.cpp builds",
+      "fileMatch": [
+        "^snap/snapcraft\\.yaml$"
+      ],
+      "matchStrings": [
+        "https://github\\.com/canonical/llama\\.cpp-builds/releases/download/(?<currentValue>[^/]+)/llamacpp"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "canonical/llama.cpp-builds",
+      "versioningTemplate": "regex:^b(?<major>\\d+)$"
+    }
+  ]
+}


### PR DESCRIPTION
Common renovate configurations for use by inference snap projects.

To use, add a renovate.json config file with the following content:
```
{
  "extends": [
    "github>canonical/inference-snaps-dev//renovate/default.jsonc#<ref>" 
  ]
}
```
Replace ref with the Git branch (e.g. v2).

The Renovate documentation claims that this reference is for [Git tags on Github](https://docs.renovatebot.com/config-presets/#github). However, this seems to work for branches too. The undelying query made to Github passes that input as a ref, which can be a tag, branch, or git hash. E.g. the branch for this PR: https://api.github.com/repos/canonical/inference-snaps-dev/contents/renovate/default.jsonc?ref=add-renovate-config