### PR TITLE
Drop recommended config from default renovate config

### DIFF
--- a/renovate/default.jsonc
+++ b/renovate/default.jsonc
@@ -1,8 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
   "git-submodules": {
     "enabled": true
   },


### PR DESCRIPTION
The recommended config is redundant as it is expected to be set on the consumer side. 