### PR TITLE
Add reusable workflow for build and tests on PR labels

### DIFF
--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -43,9 +43,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          # This shouldn't be working since the event isn't a pull_request one at this depth
-          # # Prevent usage of simulated merge commit of PR
-          # ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Prevent usage of simulated merge commit of PR
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           lfs: true
           submodules: true
 

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -33,10 +33,9 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runner) }}
 
     steps:
-      # Update snapd as we need a recent one to support components
-      - name: Update snapd
+      - name: Refresh/Install snapd
         run: |
-          sudo snap refresh snapd
+          sudo snap refresh snapd || sudo snap install snapd
 
       - name: Install Git LFS
         run: sudo apt-get update && sudo apt-get install -y git-lfs
@@ -44,8 +43,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          # Prevent usage of simulated merge commit of PR
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # This shouldn't be working since the event isn't a pull_request one at this depth
+          # # Prevent usage of simulated merge commit of PR
+          # ref: ${{ github.event.pull_request.head.sha || github.sha }}
           lfs: true
           submodules: true
 

--- a/.github/workflows/reuse-cicd.yaml
+++ b/.github/workflows/reuse-cicd.yaml
@@ -1,4 +1,6 @@
-name: Snap CICD
+# This workflow is designed to be called by another workflow on push events from the default branch.
+
+name: CICD
 
 on:
   workflow_call:
@@ -14,6 +16,7 @@ on:
           The input must be quoted and passed as a string.
         required: true
         type: string
+        default: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
 
       build-init-script:
         description: Script to run before building the snap

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -91,7 +91,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.github-token }}
         with:
-          workflow-name: ${{ github.workflow }}
+          # workflow-name: ${{ github.workflow }} 
+          # github.workflow evaluates to PR Label but gh CLI is reporting the workflow file name!
+          # Could use the following instead:
+          # gh run list --repo "$repo" --commit "$commit_sha" --json conclusion --workflow "pr-label.yaml"
+          workflow-name: ".github/workflows/pr-label.yaml"
 
   build-and-publish:
     needs: [build-pre-check]

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -95,9 +95,6 @@ jobs:
   build-and-publish:
     needs: [build-pre-check]
     if: ${{ always() && (inputs.trigger-label == 'trigger-build' || (inputs.trigger-label == 'trigger-tests' && needs.build-pre-check.outputs.build-success == 'false')) }}
-    concurrency:
-      group: pr-build-and-publish-${{ github.repository }}-${{ inputs.pr-number }}
-      cancel-in-progress: true
     uses: ./.github/workflows/build-publish-snap.yaml
     strategy:
       fail-fast: false
@@ -113,9 +110,6 @@ jobs:
   test:
     needs: [build-and-publish]
     if: ${{ always() && inputs.trigger-label == 'trigger-tests' && (needs.build-and-publish.result == 'success' || needs.build-and-publish.result == 'skipped') }}
-    concurrency:
-      group: pr-test-${{ github.repository }}-${{ inputs.pr-number }}
-      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -1,0 +1,122 @@
+# This workflow is designed to be called by another workflow on pull request labels.
+# It performs build or build+test depending on the label that triggered it.
+
+name: CI
+
+on:
+  workflow_call:
+    inputs:
+      trigger-label:
+        description: Label that triggered the workflow
+        required: true
+        type: string
+      pr-number:
+        description: Pull request number
+        required: true
+        type: string
+      build-runners:
+        description: |
+          JSON array containing runner configurations for builds.
+          Example:
+          - '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+          - '[["self-hosted", "amd64"], ["self-hosted", "arm64"]]'
+        required: false
+        type: string
+        default: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+      publish-channel-prefix:
+        description: Prefix for PR publish channel
+        required: false
+        type: string
+        default: latest/edge/pr-
+      snap-name:
+        description: Snap name for test jobs
+        required: true
+        type: string
+      test-chat-tps:
+        description: Enable chat TPS test
+        required: false
+        type: boolean
+        default: true
+      test-image-prompt:
+        description: Enable image prompt test
+        required: false
+        type: boolean
+        default: true
+      test-jobs-matrix:
+        description: |
+          JSON array of test job objects
+          Example:
+          [
+            {"job-queue":"maas-systemtests-amd64","provision-data":"distro: noble","select-engine":"cpu"},
+            {"job-queue":"anbox-nvidia-amd64","provision-data":"distro: noble","install-nvidia-driver-version":595,"select-engine":"nvidia-gpu","expected-tps":9.4}
+          ]
+        required: false
+        type: string
+        default: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+    secrets:
+      store-credentials:
+        description: Snap Store credentials for publishing PR builds
+        required: true
+
+jobs:
+  remove-trigger-labels:
+    if: ${{ inputs.trigger-label == 'trigger-build' || inputs.trigger-label == 'trigger-tests' }}
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/remove-label.yaml
+    with:
+      label: ${{ inputs.trigger-label }}
+
+  build-pre-check:
+    if: ${{ inputs.trigger-label == 'trigger-tests' }}
+    runs-on: ubuntu-latest
+    outputs:
+      build-success: ${{ steps.build-pre-check.outputs.build-success }}
+    steps:
+      - id: build-pre-check
+        name: Check for existing successful build
+        uses: canonical/inference-snaps-testing/.github/actions/build-pre-check@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          workflow-name: ${{ github.workflow }}
+
+  build-and-publish:
+    needs: [build-pre-check]
+    if: ${{ always() && (inputs.trigger-label == 'trigger-build' || (inputs.trigger-label == 'trigger-tests' && needs.build-pre-check.outputs.build-success == 'false')) }}
+    uses: ./.github/workflows/build-publish-snap.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJSON(inputs.build-runners) }}
+    with:
+      runner: "${{ toJSON(matrix.runner) }}"
+      init-build-script: download-models.sh # Replace this with 'make download-models'
+      publish-channel: ${{ inputs.publish-channel-prefix }}${{ inputs.pr-number }}
+    secrets:
+      store-credentials: ${{ secrets.store-credentials }}
+
+  test:
+    needs: [build-and-publish]
+    if: ${{ always() && inputs.trigger-label == 'trigger-tests' && (needs.build-and-publish.result == 'success' || needs.build-and-publish.result == 'skipped') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        jobs: ${{ fromJSON(inputs.test-jobs-matrix) }}
+    uses: canonical/inference-snaps-testing/.github/workflows/test-snap.yaml@v1
+    secrets: inherit
+    with:
+      job-queue: ${{ matrix.jobs.job-queue }}
+      provision-data: ${{ matrix.jobs.provision-data }}
+      snap-name: ${{ inputs.snap-name }}
+      snap-channel: ${{ inputs.publish-channel-prefix }}${{ inputs.pr-number }}
+      install-nvidia-driver-version: ${{ matrix.jobs.install-nvidia-driver-version }}
+      install-intel-npu-driver: ${{ matrix.jobs.install-intel-npu-driver == true }}
+      snap-connections: ${{ matrix.jobs.snap-connections }}
+      expected-engine: ${{ matrix.jobs.expected-engine }}
+      select-engine: ${{ matrix.jobs.select-engine }}
+      test-chat-tps: ${{ inputs.test-chat-tps }}
+      expected-tps: ${{ matrix.jobs.expected-tps }}
+      test-image-prompt: ${{ inputs.test-image-prompt }}
+      devmode: ${{ matrix.jobs.devmode == true }}

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -92,11 +92,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.github-token }}
         with:
-          workflow-name: ${{ github.workflow }} 
-          # # github.workflow evaluates to PR Label but gh CLI is reporting the workflow file name!
-          # # Could use the following instead:
-          # # gh run list --repo "$repo" --commit "$commit_sha" --json conclusion --workflow "pr-label.yaml"
-          # workflow-name: ".github/workflows/pr-label.yaml"
+          workflow-name: ${{ github.workflow }}
 
   build-and-publish:
     needs: [build-pre-check]
@@ -110,7 +106,7 @@ jobs:
         runner: ${{ fromJSON(inputs.build-runners) }}
     with:
       runner: "${{ toJSON(matrix.runner) }}"
-      init-build-script: download-models.sh # TODO: Replace this with a standard make recipe for model downloads
+      init-build-script: download-models.sh
       publish-channel: ${{ inputs.store-track }}/edge/pr-${{ inputs.pr-number }} # E.g. latest/edge/pr-123
     secrets:
       store-credentials: ${{ secrets.store-credentials }}

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -55,9 +55,8 @@ on:
             {"job-queue":"maas-systemtests-amd64","provision-data":"distro: noble","select-engine":"cpu"},
             {"job-queue":"anbox-nvidia-amd64","provision-data":"distro: noble","install-nvidia-driver-version":595,"select-engine":"nvidia-gpu","expected-tps":9.4}
           ]
-        required: false
+        required: true
         type: string
-        default: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
     secrets:
       store-credentials:
         description: Snap Store credentials for publishing PR builds
@@ -68,6 +67,7 @@ on:
 
 jobs:
   remove-trigger-labels:
+    # Run only for trigger labels, not any other label
     if: ${{ inputs.trigger-label == 'trigger-build' || inputs.trigger-label == 'trigger-tests' }}
     permissions:
       contents: read
@@ -79,7 +79,8 @@ jobs:
   # TODO: drop this job and make the build-publish job detect if it needs to build and publish
   build-pre-check:
     name: Check for existing build
-    if: ${{ inputs.trigger-label == 'trigger-tests' }}
+    # Run only for trigger labels, not any other label
+    if: ${{ inputs.trigger-label == 'trigger-build' || inputs.trigger-label == 'trigger-tests' }}
     runs-on: ubuntu-latest
     outputs:
       build-success: ${{ steps.build-pre-check.outputs.build-success }}
@@ -94,7 +95,9 @@ jobs:
 
   build-and-publish:
     needs: [build-pre-check]
-    if: ${{ !cancelled() && (inputs.trigger-label == 'trigger-build' || (inputs.trigger-label == 'trigger-tests' && needs.build-pre-check.outputs.build-success == 'false')) }}
+    # Run only for trigger labels, not any other label
+    # Run only if not already built successfully
+    if: ${{ (inputs.trigger-label == 'trigger-build' || inputs.trigger-label == 'trigger-tests') && needs.build-pre-check.outputs.build-success == 'false' }}
     uses: ./.github/workflows/build-publish-snap.yaml
     strategy:
       fail-fast: false
@@ -109,7 +112,10 @@ jobs:
 
   test:
     needs: [build-and-publish]
-    if: ${{ !cancelled() && inputs.trigger-label == 'trigger-tests' && (needs.build-and-publish.result == 'success' || needs.build-and-publish.result == 'skipped') }}
+    # Run only for trigger-tests label, not any other label
+    # Run even if previous job was skipped (!cancelled)
+    # Run only if build hasn't failed
+    if: ${{ inputs.trigger-label == 'trigger-tests' && !cancelled() && needs.build-and-publish.result != 'failed' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -95,6 +95,9 @@ jobs:
   build-and-publish:
     needs: [build-pre-check]
     if: ${{ always() && (inputs.trigger-label == 'trigger-build' || (inputs.trigger-label == 'trigger-tests' && needs.build-pre-check.outputs.build-success == 'false')) }}
+    concurrency:
+      group: pr-build-and-publish-${{ github.repository }}-${{ inputs.pr-number }}
+      cancel-in-progress: true
     uses: ./.github/workflows/build-publish-snap.yaml
     strategy:
       fail-fast: false
@@ -110,6 +113,9 @@ jobs:
   test:
     needs: [build-and-publish]
     if: ${{ always() && inputs.trigger-label == 'trigger-tests' && (needs.build-and-publish.result == 'success' || needs.build-and-publish.result == 'skipped') }}
+    concurrency:
+      group: pr-test-${{ github.repository }}-${{ inputs.pr-number }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -3,6 +3,11 @@
 
 name: CI
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -37,23 +37,25 @@ on:
         description: Snap name for test jobs
         required: true
         type: string
-      test-chat-tps:
-        description: Enable chat TPS test
-        required: false
-        type: boolean
-        default: false
-      test-image-prompt:
-        description: Enable image prompt test
-        required: false
-        type: boolean
-        default: false
       test-jobs-matrix:
         description: |
           JSON array of test job objects
           Example:
           [
-            {"job-queue":"maas-systemtests-amd64","provision-data":"distro: noble","select-engine":"cpu"},
-            {"job-queue":"anbox-nvidia-amd64","provision-data":"distro: noble","install-nvidia-driver-version":595,"select-engine":"nvidia-gpu","expected-tps":9.4}
+            {
+              "job-queue": "maas-systemtests-amd64",
+              "provision-data": "distro: noble",
+              "select-engine": "cpu",
+              "test-chat-tps": true
+            },
+            {
+              "job-queue": "anbox-nvidia-amd64",
+              "provision-data": "distro: noble",
+              "install-nvidia-driver-version": 595,
+              "select-engine": "nvidia-gpu",
+              "test-chat-tps": true,
+              "expected-tps": 9.4
+            }
           ]
         required: true
         type: string
@@ -76,7 +78,6 @@ jobs:
     with:
       label: ${{ inputs.trigger-label }}
 
-  # TODO: drop this job and make the build-publish job detect if it needs to build and publish
   build-pre-check:
     name: Check for existing build
     # Run only for trigger labels, not any other label
@@ -136,7 +137,7 @@ jobs:
       snap-connections: ${{ matrix.jobs.snap-connections }}
       expected-engine: ${{ matrix.jobs.expected-engine }}
       select-engine: ${{ matrix.jobs.select-engine }}
-      test-chat-tps: ${{ inputs.test-chat-tps }}
+      test-chat-tps: ${{ matrix.jobs.test-chat-tps == true }}
       expected-tps: ${{ matrix.jobs.expected-tps }}
-      test-image-prompt: ${{ inputs.test-image-prompt }}
+      test-image-prompt: ${{ matrix.jobs.test-image-prompt == true}}
       devmode: ${{ matrix.jobs.devmode == true }}

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -91,11 +91,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.github-token }}
         with:
-          # workflow-name: ${{ github.workflow }} 
-          # github.workflow evaluates to PR Label but gh CLI is reporting the workflow file name!
-          # Could use the following instead:
-          # gh run list --repo "$repo" --commit "$commit_sha" --json conclusion --workflow "pr-label.yaml"
-          workflow-name: ".github/workflows/pr-label.yaml"
+          workflow-name: ${{ github.workflow }} 
+          # # github.workflow evaluates to PR Label but gh CLI is reporting the workflow file name!
+          # # Could use the following instead:
+          # # gh run list --repo "$repo" --commit "$commit_sha" --json conclusion --workflow "pr-label.yaml"
+          # workflow-name: ".github/workflows/pr-label.yaml"
 
   build-and-publish:
     needs: [build-pre-check]

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -76,7 +76,9 @@ jobs:
     with:
       label: ${{ inputs.trigger-label }}
 
+  # TODO: drop this job and make the build-publish job detect if it needs to build and publish
   build-pre-check:
+    name: Check for existing build
     if: ${{ inputs.trigger-label == 'trigger-tests' }}
     runs-on: ubuntu-latest
     outputs:
@@ -100,7 +102,7 @@ jobs:
         runner: ${{ fromJSON(inputs.build-runners) }}
     with:
       runner: "${{ toJSON(matrix.runner) }}"
-      init-build-script: download-models.sh # Replace this with 'make download-models'
+      init-build-script: download-models.sh # TODO: Replace this with a standard make recipe for model downloads
       publish-channel: ${{ inputs.publish-channel-prefix }}${{ inputs.pr-number }}
     secrets:
       store-credentials: ${{ secrets.store-credentials }}

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -57,6 +57,9 @@ on:
       store-credentials:
         description: Snap Store credentials for publishing PR builds
         required: true
+      github-token:
+        description: GitHub token used by build pre-check and label operations
+        required: true
 
 jobs:
   remove-trigger-labels:
@@ -78,7 +81,7 @@ jobs:
         name: Check for existing successful build
         uses: canonical/inference-snaps-testing/.github/actions/build-pre-check@v1
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.github-token }}
         with:
           workflow-name: ${{ github.workflow }}
 

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -28,11 +28,11 @@ on:
         required: false
         type: string
         default: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
-      publish-channel-prefix:
-        description: Prefix for PR publish channel
+      store-track:
+        description: Snap Store track to publish to
         required: false
         type: string
-        default: latest/edge/pr-
+        default: "latest"
       snap-name:
         description: Snap name for test jobs
         required: true
@@ -41,12 +41,12 @@ on:
         description: Enable chat TPS test
         required: false
         type: boolean
-        default: true
+        default: false
       test-image-prompt:
         description: Enable image prompt test
         required: false
         type: boolean
-        default: true
+        default: false
       test-jobs-matrix:
         description: |
           JSON array of test job objects
@@ -110,7 +110,7 @@ jobs:
     with:
       runner: "${{ toJSON(matrix.runner) }}"
       init-build-script: download-models.sh # TODO: Replace this with a standard make recipe for model downloads
-      publish-channel: ${{ inputs.publish-channel-prefix }}${{ inputs.pr-number }}
+      publish-channel: ${{ inputs.store-track }}/edge/pr-${{ inputs.pr-number }} # E.g. latest/edge/pr-123
     secrets:
       store-credentials: ${{ secrets.store-credentials }}
 
@@ -130,7 +130,7 @@ jobs:
       job-queue: ${{ matrix.jobs.job-queue }}
       provision-data: ${{ matrix.jobs.provision-data }}
       snap-name: ${{ inputs.snap-name }}
-      snap-channel: ${{ inputs.publish-channel-prefix }}${{ inputs.pr-number }}
+      snap-channel: ${{ inputs.store-track }}/edge/pr-${{ inputs.pr-number }} # E.g. latest/edge/pr-123
       install-nvidia-driver-version: ${{ matrix.jobs.install-nvidia-driver-version }}
       install-intel-npu-driver: ${{ matrix.jobs.install-intel-npu-driver == true }}
       snap-connections: ${{ matrix.jobs.snap-connections }}

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -94,7 +94,7 @@ jobs:
 
   build-and-publish:
     needs: [build-pre-check]
-    if: ${{ always() && (inputs.trigger-label == 'trigger-build' || (inputs.trigger-label == 'trigger-tests' && needs.build-pre-check.outputs.build-success == 'false')) }}
+    if: ${{ !cancelled() && (inputs.trigger-label == 'trigger-build' || (inputs.trigger-label == 'trigger-tests' && needs.build-pre-check.outputs.build-success == 'false')) }}
     uses: ./.github/workflows/build-publish-snap.yaml
     strategy:
       fail-fast: false
@@ -109,7 +109,7 @@ jobs:
 
   test:
     needs: [build-and-publish]
-    if: ${{ always() && inputs.trigger-label == 'trigger-tests' && (needs.build-and-publish.result == 'success' || needs.build-and-publish.result == 'skipped') }}
+    if: ${{ !cancelled() && inputs.trigger-label == 'trigger-tests' && (needs.build-and-publish.result == 'success' || needs.build-and-publish.result == 'skipped') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Changes between the newly added reusable workflow and workflows used on existing inference snaps:

- init-build-script is deprecated. It is hardcoded to `download-models.sh` and the caller repo can expect that it will be run if provided. Future version of this reusable workflow will instead run a specific make recipe to download models.
- The build pre-checks applies to both build and test triggers. If a build is detected as present, subsequent requests to build and test get skipped. This change was done primarily to simplify the job conditions. To force a rebuild, one can still delete the workflow log or push an empty commit.
- Support for custom labels has been dropped. Caller must now use trigger-build and trigger-tests labels.

Example caller workflow:
```yaml
name: PR Label

on:
  pull_request:
    types: [ labeled ]

concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
  cancel-in-progress: true

permissions:
  contents: read
  pull-requests: write
  actions: read

jobs:

  build-test:
    # The applied label is used to select build/test tasks and as job's display name.
    name: ${{ github.event.label.name }}
    uses: canonical/inference-snaps-dev/.github/workflows/reuse-pr-build-test.yaml@v2
    with:
      trigger-label: ${{ github.event.label.name }}
      pr-number: "${{ github.event.pull_request.number }}"
      build-runners: |
        [
          ["amd64", "resolute", "self-hosted"],
          ["arm64", "resolute", "self-hosted"]
        ]
      test-jobs-matrix: |
        [
          {
            "job-queue": "maas-systemtests-amd64",
            "provision-data": "distro: noble",
            "select-engine": "cpu",
            "test-chat-tps": true
          },
          {
            "job-queue": "anbox-nvidia-amd64",
            "provision-data": "distro: noble",
            "install-nvidia-driver-version": 595,
            "select-engine": "nvidia-gpu",
            "test-chat-tps": true,
            "expected-tps": 9.4
          }
        ]
      snap-name: smollm2
    secrets:
      store-credentials: ${{ secrets.STORE_LOGIN_PR }}
      github-token: ${{ secrets.GITHUB_TOKEN }}

```

Example runs:

<img width="541" height="414" alt="image" src="https://github.com/user-attachments/assets/d1aede14-694f-48d1-9e16-52f9a39d6af0" />

<img width="958" height="577" alt="image" src="https://github.com/user-attachments/assets/69b021a0-c3bd-43f9-8f46-9eb3311ed32b" />