### PR TITLE
Pass Testflinger credentials as workflow inputs

### DIFF
--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -128,7 +128,7 @@ jobs:
       fail-fast: false
       matrix:
         jobs: ${{ fromJSON(inputs.test-jobs-matrix) }}
-    uses: canonical/inference-snaps-testing/.github/workflows/test-snap.yaml@tf-auth # v1
+    uses: canonical/inference-snaps-testing/.github/workflows/test-snap.yaml@v1
     with:
       job-queue: ${{ matrix.jobs.job-queue }}
       provision-data: ${{ matrix.jobs.provision-data }}

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -127,7 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         jobs: ${{ fromJSON(inputs.test-jobs-matrix) }}
-    uses: canonical/inference-snaps-testing/.github/workflows/test-snap.yaml@v1
+    uses: canonical/inference-snaps-testing/.github/workflows/test-snap.yaml@tf-auth # v1
     with:
       job-queue: ${{ matrix.jobs.job-queue }}
       provision-data: ${{ matrix.jobs.provision-data }}

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -66,6 +66,12 @@ on:
       github-token:
         description: GitHub token used by build pre-check and label operations
         required: true
+      testflinger-client-id:
+        description: Testflinger client ID for test job
+        required: true
+      testflinger-secret-key:
+        description: Testflinger secret key for test job
+        required: true
 
 jobs:
   remove-trigger-labels:
@@ -122,7 +128,6 @@ jobs:
       matrix:
         jobs: ${{ fromJSON(inputs.test-jobs-matrix) }}
     uses: canonical/inference-snaps-testing/.github/workflows/test-snap.yaml@v1
-    secrets: inherit
     with:
       job-queue: ${{ matrix.jobs.job-queue }}
       provision-data: ${{ matrix.jobs.provision-data }}
@@ -137,3 +142,6 @@ jobs:
       expected-tps: ${{ matrix.jobs.expected-tps }}
       test-image-prompt: ${{ matrix.jobs.test-image-prompt == true}}
       devmode: ${{ matrix.jobs.devmode == true }}
+    secrets:
+      testflinger-client-id: ${{ secrets.testflinger-client-id }}
+      testflinger-secret-key: ${{ secrets.testflinger-secret-key }}

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -59,15 +59,16 @@ on:
           ]
         required: true
         type: string
+      testflinger-client-id:
+        description: Testflinger client ID for test job
+        required: true
+        type: string
     secrets:
       store-credentials:
         description: Snap Store credentials for publishing PR builds
         required: true
       github-token:
         description: GitHub token used by build pre-check and label operations
-        required: true
-      testflinger-client-id:
-        description: Testflinger client ID for test job
         required: true
       testflinger-secret-key:
         description: Testflinger secret key for test job
@@ -142,6 +143,6 @@ jobs:
       expected-tps: ${{ matrix.jobs.expected-tps }}
       test-image-prompt: ${{ matrix.jobs.test-image-prompt == true}}
       devmode: ${{ matrix.jobs.devmode == true }}
+      testflinger-client-id: ${{ inputs.testflinger-client-id }}
     secrets:
-      testflinger-client-id: ${{ secrets.testflinger-client-id }}
       testflinger-secret-key: ${{ secrets.testflinger-secret-key }}


### PR DESCRIPTION
Testflinger has started mandating authentication from the self-hosted runners.

Depends on:
- https://github.com/canonical/inference-snaps-testing/pull/34