### PR TITLE
Rename build-runners parameter to build-runner

### DIFF
--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -19,7 +19,7 @@ on:
         description: Pull request number
         required: true
         type: string
-      build-runners:
+      build-runner:
         description: |
           JSON array containing runner configurations for builds.
           Example:

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ fromJSON(inputs.build-runners) }}
+        runner: ${{ fromJSON(inputs.build-runner) }}
     with:
       runner: "${{ toJSON(matrix.runner) }}"
       init-build-script: download-models.sh


### PR DESCRIPTION
This is for consistency with other runner inputs in this and other workflows.