### PR TITLE
Deprecate init script in favor of make init

### DIFF
--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -18,8 +18,9 @@ on:
         description: Snap Store channel for publishing the snap
         required: true
         type: string
-      init-build-script:
-        description: Script to run before building the snap
+      init-build-script: # Deprecated
+        deprecationMessage: Supply a Makefile with 'make init' target instead of passing a script name. 
+        description: Script to run before building the snap. 
         required: false
         type: string
     secrets:
@@ -50,8 +51,26 @@ jobs:
 
       - name: Init build environment
         run: |
+          # Try Makefile init target first
+          if [ -f Makefile ]; then
+            if make init; then
+              exit 0
+            else
+              # Once deprecated inputs are removed, lack of a "make init" would mean skipping of the initialization.
+              echo "Makefile init target failed. Trying other methods..."
+            fi
+          fi
+          
+          # Try deprecated download-models.sh script if Makefile init didn't work
+          if [ -f download-models.sh ]; then
+            ./download-models.sh
+            exit 0
+          fi
+          
+          # Try custom script if provided via the deprecated input
           if [ -n "${{ inputs.init-build-script }}" ]; then
             ./"${{ inputs.init-build-script }}"
+            exit 0
           fi
 
       - name: Build snap

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -19,8 +19,10 @@ on:
         required: true
         type: string
       init-build-script: # Deprecated
-        deprecationMessage: Supply a Makefile with 'make init' target instead of passing a script name. 
-        description: Script to run before building the snap. 
+        description: |
+          Script to run before building the snap. 
+          
+          Deprecated: Supply a Makefile with 'make init' target instead of passing a script name. 
         required: false
         type: string
     secrets:

--- a/.github/workflows/build-publish-snap.yaml
+++ b/.github/workflows/build-publish-snap.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Init build environment
         run: |
-          # Try Makefile init target first
+          # Try make init
           if [ -f Makefile ]; then
             if make init; then
               exit 0
@@ -63,7 +63,7 @@ jobs:
             fi
           fi
           
-          # Try deprecated download-models.sh script if Makefile init didn't work
+          # Try deprecated download-models.sh script
           if [ -f download-models.sh ]; then
             ./download-models.sh
             exit 0

--- a/.github/workflows/reuse-cicd.yaml
+++ b/.github/workflows/reuse-cicd.yaml
@@ -18,7 +18,8 @@ on:
         type: string
         default: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
 
-      build-init-script:
+      build-init-script: # Deprecated
+        deprecationMessage: Supply a Makefile with 'make init' target instead of passing a script name. 
         description: Script to run before building the snap
         required: false
         type: string

--- a/.github/workflows/reuse-cicd.yaml
+++ b/.github/workflows/reuse-cicd.yaml
@@ -19,8 +19,10 @@ on:
         default: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
 
       build-init-script: # Deprecated
-        deprecationMessage: Supply a Makefile with 'make init' target instead of passing a script name. 
-        description: Script to run before building the snap
+        description: |
+          Script to run before building the snap
+
+          Deprecated: Supply a Makefile with 'make init' target instead of passing a script name. 
         required: false
         type: string
 

--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -113,7 +113,6 @@ jobs:
         runner: ${{ fromJSON(inputs.build-runner) }}
     with:
       runner: "${{ toJSON(matrix.runner) }}"
-      init-build-script: download-models.sh
       publish-channel: ${{ inputs.store-track }}/edge/pr-${{ inputs.pr-number }} # E.g. latest/edge/pr-123
     secrets:
       store-credentials: ${{ secrets.store-credentials }}


### PR DESCRIPTION
Example usage:
- Use of deprecated input: https://github.com/canonical/smollm2-snap/pull/17
- Makefile with init target: https://github.com/canonical/smollm2-snap/pull/3