### PR TITLE
Remove default arm build for PR workflow

### DIFF
--- a/.github/workflows/reuse-pr-build-test.yaml
+++ b/.github/workflows/reuse-pr-build-test.yaml
@@ -27,7 +27,7 @@ on:
           - '[["self-hosted", "amd64"], ["self-hosted", "arm64"]]'
         required: false
         type: string
-        default: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+        default: '["ubuntu-latest"]'
       store-track:
         description: Snap Store track to publish to
         required: false


### PR DESCRIPTION
Reduce the default to the latest Ubuntu on x86. Anything else should be passed as input.

Using latest and not 24.04 so that callers do not make a 24.04 assumption, forcing the reusable workflow to stay pinned to that specific version. 