### PR TITLE
Add reusable workflow for workflow failure triage

### DIFF
--- a/.github/workflows/reuse-triage-failures.yaml
+++ b/.github/workflows/reuse-triage-failures.yaml
@@ -29,7 +29,7 @@ on:
         required: true
         type: string
       infra-patterns:
-        description: Newline-separated list of patterns that indicate an infrastructure failure
+        description: Newline-separated list of extended regular expression (ERE) patterns that match infrastructure failures in logs
         required: false
         type: string
         default: |
@@ -90,7 +90,7 @@ jobs:
             LOGS=$(gh api "repos/${REPO}/actions/jobs/${JOB_ID}/logs")
 
             set +o pipefail
-            INFRA_ERR=$(echo "${LOGS}" | grep -oE "${INFRA_PATTERN_RE}" | head -1)
+            INFRA_ERR=$(echo "${LOGS}" | grep --only-matching --extended-regexp "${INFRA_PATTERN_RE}" | head -1)
             set -o pipefail
 
             if [[ -n "${INFRA_ERR}" ]]; then

--- a/.github/workflows/reuse-triage-failures.yaml
+++ b/.github/workflows/reuse-triage-failures.yaml
@@ -1,0 +1,132 @@
+# This is a reusable workflow that can be called by other workflows to triage failed jobs in a workflow run.
+# It classifies failed jobs that match certain patterns as infrastructure failures and retries them if all failed jobs are classified as such.
+# The retries are limited to a set maximum of attempts per run, including manual retries.
+
+name: Triage Failures
+
+on:
+  workflow_call:
+    inputs:
+      workflow-run:
+        description: JSON of github.event.workflow_run
+        required: true
+        type: string
+      infra-patterns:
+        description: Newline-separated list of patterns that indicate an infrastructure failure
+        required: false
+        type: string
+        default: |
+          Status: error while processing
+          MAAS reports Failed Deployment
+
+jobs:
+  triage:
+    name: Triage Job Failures
+    if: fromJson(inputs.workflow-run).conclusion == 'failure' && fromJson(inputs.workflow-run).run_attempt <= 5
+    runs-on: ubuntu-slim
+    permissions:
+      actions: write # required to re-run jobs
+
+    steps:
+      - name: Classify failures and retry if infra-related
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_RUN_JSON: "${{ inputs.workflow-run }}"
+          INFRA_PATTERNS_INPUT: "${{ inputs.infra-patterns }}"
+        run: |
+          set -euo pipefail
+
+          RUN_ID=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.id')
+          REPO=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.repository.full_name')
+
+          # Build grep -E pattern from newline-separated input
+          INFRA_PATTERN_RE=$(echo "${INFRA_PATTERNS_INPUT}" | grep -v '^[[:space:]]*$' | paste -sd '|')
+
+          echo "==> Triggered by workflow run: ${RUN_ID}"
+          echo "==> Fetching failed jobs..."
+
+          FAILED_JOBS=$(gh api \
+            "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
+            --jq '[.jobs[] | select(.conclusion == "failure")]')
+
+          JOB_COUNT=$(echo "${FAILED_JOBS}" | jq 'length')
+          echo "==> Found ${JOB_COUNT} failed job(s)"
+
+          if [[ "${JOB_COUNT}" -eq 0 ]]; then
+            echo "==> No failed jobs. Nothing to triage."
+            exit 0
+          fi
+
+          ALL_INFRA=true
+          SUMMARY=""
+
+          while IFS= read -r JOB; do
+            JOB_ID=$(echo "${JOB}" | jq -r '.id')
+            JOB_NAME=$(echo "${JOB}" | jq -r '.name')
+            echo ""
+            echo "--- Inspecting: ${JOB_NAME} (id=${JOB_ID}) ---"
+
+            LOGS=$(gh api \
+              "repos/${REPO}/actions/jobs/${JOB_ID}/logs" \
+              || true)
+
+            if echo "${LOGS}" | grep -qE "${INFRA_PATTERN_RE}"; then
+              MATCHED=$(echo "${LOGS}" | grep -oE "${INFRA_PATTERN_RE}" | head -1)
+              echo "==> INFRA failure: '${MATCHED}'"
+              SUMMARY="${SUMMARY}\n- [INFRA]     ${JOB_NAME}: ${MATCHED}"
+            else
+              echo "==> NON-INFRA failure: will not auto-retry"
+              SUMMARY="${SUMMARY}\n- [NON-INFRA] ${JOB_NAME}: no infra pattern matched"
+              ALL_INFRA=false
+            fi
+          done < <(echo "${FAILED_JOBS}" | jq -c '.[]')
+
+          echo ""
+          echo "==> Triage summary:"
+          echo -e "${SUMMARY}"
+          echo ""
+
+          if [[ "${ALL_INFRA}" == "true" ]]; then
+            echo "==> All failures are infrastructure-related. Re-running failed jobs..."
+            gh api \
+              --method POST \
+              "repos/${REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs"
+            echo "==> Re-run triggered."
+          else
+            echo "==> Non-infrastructure failures present. Skipping auto-retry."
+            echo "==> Manual investigation required."
+            exit 1
+          fi
+
+      - name: Write job summary
+        if: always()
+        env:
+          WORKFLOW_RUN_JSON: "${{ inputs.workflow-run }}"
+        run: |
+          RUN_NUMBER=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.run_number')
+          RUN_URL=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.html_url')
+          WORKFLOW_NAME=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.name')
+          AUTHOR=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.actor.login')
+          ATTEMPT=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.run_attempt')
+          HEAD_BRANCH=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.head_branch')
+          HEAD_SHA=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.head_sha')
+
+          echo "### Triage Details" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Detail | Value |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "|--------|-------|" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Workflow | ${WORKFLOW_NAME} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Run Attempt | [${RUN_NUMBER}#${ATTEMPT}](${RUN_URL}?attempt=${ATTEMPT}) |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Author | \`${AUTHOR}\` |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Branch | \`${HEAD_BRANCH}\` |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Commit | [\`${HEAD_SHA:0:7}\`](../../commit/${HEAD_SHA}) |" >> "${GITHUB_STEP_SUMMARY}"
+
+          PR_COUNT=$(echo "${WORKFLOW_RUN_JSON}" | jq '.pull_requests | length')
+          if [[ "${PR_COUNT}" -gt 0 ]]; then
+            PR_NUMBER=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.pull_requests[0].number')
+            PR_TITLE=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.pull_requests[0].title')
+            echo "| PR | [#${PR_NUMBER}: ${PR_TITLE}](../../pull/${PR_NUMBER}) |" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "See the step logs above for the per-job failure classification." >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/reuse-triage-failures.yaml
+++ b/.github/workflows/reuse-triage-failures.yaml
@@ -1,6 +1,23 @@
 # This is a reusable workflow that can be called by other workflows to triage failed jobs in a workflow run.
-# It classifies failed jobs that match certain patterns as infrastructure failures and retries them if all failed jobs are classified as such.
+# It classifies failed jobs that match certain patterns as infrastructure failures and retries them if a failed job is classified as such.
 # The retries are limited to a set maximum of attempts per run, including manual retries.
+
+# The workflow reruns all failed jobs if it detect an infra-related issue in one failing job.
+#
+# Example 1:
+# - Job A failed due to infra issue
+# - Job B failed due to driver issue
+# - Job C succeeded
+# -> Jobs A and B will be retried.
+#
+# Example 2:
+# - Job A failed due to packaging issue
+# - Job B failed due to packaging issue
+# - Job C succeeded
+# -> No jobs will be retried.
+#
+# This is a shortcoming of the GitHub API, which does not allow re-running a subset of failed jobs.
+# Rerunning one specific failed job is possible, but only in a sequential order: rerun one, wait for it to complete, rerun the next.
 
 name: Triage Failures
 
@@ -21,14 +38,17 @@ on:
 
 jobs:
   triage:
-    name: Triage Job Failures
-    if: fromJson(inputs.workflow-run).conclusion == 'failure' && fromJson(inputs.workflow-run).run_attempt <= 2
+    name: Triage job failures
+    if: |
+      fromJson(inputs.workflow-run).conclusion == 'failure' &&
+      fromJson(inputs.workflow-run).run_attempt <= 3
     runs-on: ubuntu-slim
     permissions:
       actions: write # required to rerun jobs
 
     steps:
-      - name: Classify failures and retry if infra-related
+      - name: Classify failures
+        id: classify
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_RUN_JSON: "${{ inputs.workflow-run }}"
@@ -43,11 +63,9 @@ jobs:
           INFRA_PATTERN_RE=$(printf '%s\n' "${INFRA_PATTERNS_INPUT}" | sed '/^[[:space:]]*$/d' | paste -sd '|')
 
           echo "Triggered by workflow run: ${RUN_ID}"
+          
           echo "Fetching failed jobs..."
-
-          FAILED_JOBS=$(gh api \
-            "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
-            --jq '[.jobs[] | select(.conclusion == "failure")]')
+          FAILED_JOBS=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --jq '[.jobs[] | select(.conclusion == "failure")]')
 
           JOB_COUNT=$(echo "${FAILED_JOBS}" | jq 'length')
           echo "Found ${JOB_COUNT} failed job(s)"
@@ -58,10 +76,13 @@ jobs:
           fi
 
           HAS_INFRA_ERR=false
-          INFRA_JOB_IDS=()
           SUMMARY=""
 
-          while IFS= read -r JOB; do
+          # Load jobs into array
+          mapfile -t JOBS < <(echo "${FAILED_JOBS}" | jq -c '.[]')
+
+          # Inspect each failed job
+          for JOB in "${JOBS[@]}"; do
             JOB_ID=$(echo "${JOB}" | jq -r '.id')
             JOB_NAME=$(echo "${JOB}" | jq -r '.name')
             echo -e "\nInspecting: ${JOB_NAME} (id=${JOB_ID})"
@@ -76,40 +97,33 @@ jobs:
               echo "INFRA failure: '${INFRA_ERR}'"
               SUMMARY="${SUMMARY}\n- ⚠️ ${JOB_NAME}: ${INFRA_ERR} -> retry"
               HAS_INFRA_ERR=true
-              INFRA_JOB_IDS+=("${JOB_ID}")
             else
               echo "NON-INFRA failure: will not auto-retry"
               SUMMARY="${SUMMARY}\n- ❌ ${JOB_NAME}: no infra pattern matched"
             fi
-          done < <(echo "${FAILED_JOBS}" | jq -c '.[]')
+          done
 
-          if [[ -n "${SUMMARY}" ]]; then
-            echo "### Summary" >> "${GITHUB_STEP_SUMMARY}"
-            echo "" >> "${GITHUB_STEP_SUMMARY}"
-            echo -e "${SUMMARY}" >> "${GITHUB_STEP_SUMMARY}"
-            echo "" >> "${GITHUB_STEP_SUMMARY}"
-          fi
+          echo "has_infra_err=${HAS_INFRA_ERR}" >> "${GITHUB_OUTPUT}"
+          echo "summary=${SUMMARY}" >> "${GITHUB_OUTPUT}"
 
-          if [[ "${HAS_INFRA_ERR}" == "true" ]]; then
-            echo -e "\nInfrastructure failures detected. Re-running failed jobs..."
-            
+      - name: Retry if infra-related
+        if: steps.classify.outputs.has_infra_err == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_RUN_JSON: "${{ inputs.workflow-run }}"
+        run: |
+          set -euo pipefail
 
-            # The /rerun endpoint can be used to rerun a single job, but it does not support multiple jobs in one request.
-            # A subsequent run of a single job can only be triggered once the previous run has completed.
-            #
-            # Rerun all failed jobs:
-            if gh api --method POST "repos/${REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs"; then
-              echo -e "\nSuccessfully triggered rerun for failed jobs"
+          RUN_ID=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.id')
+          REPO=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.repository.full_name')
 
-              echo "" >> "${GITHUB_STEP_SUMMARY}"
-              echo "> [!NOTE]" >> "${GITHUB_STEP_SUMMARY}"
-              echo "> On a failure, all failed jobs are rerun, not just infra-related ones." >> "${GITHUB_STEP_SUMMARY}"
-            else
-              echo -e "\nFailed to trigger rerun for jobs" >&2
-              exit 1
-            fi
+          echo -e "\nInfrastructure failures detected. Re-running all failed jobs..."
+          
+          # Rerun all failed jobs, even if some are not infra-related (see comment at the top of this workflow):
+          if gh api --method POST "repos/${REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs"; then
+            echo -e "\nSuccessfully triggered rerun for failed jobs"
           else
-            echo "No infrastructure failures detected. Skipping auto-retry."
+            echo -e "\nFailed to trigger rerun for jobs" >&2
             exit 1
           fi
 
@@ -126,8 +140,16 @@ jobs:
           HEAD_BRANCH: ${{ fromJson(inputs.workflow-run).head_branch }}
           HEAD_SHA: ${{ fromJson(inputs.workflow-run).head_sha }}
           REPO: ${{ fromJson(inputs.workflow-run).repository.full_name }}
+          SUMMARY: ${{ steps.classify.outputs.summary }}
         run: |
-          echo "### Details" >> "${GITHUB_STEP_SUMMARY}"
+          if [[ -n "${SUMMARY}" ]]; then
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+            echo "### Classification summary" >> "${GITHUB_STEP_SUMMARY}"
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+            echo -e "${SUMMARY}" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+          
+          echo "### Triage details" >> "${GITHUB_STEP_SUMMARY}"
           echo "" >> "${GITHUB_STEP_SUMMARY}"
           echo "| Detail | Value |" >> "${GITHUB_STEP_SUMMARY}"
           echo "|--------|-------|" >> "${GITHUB_STEP_SUMMARY}"
@@ -143,4 +165,3 @@ jobs:
             PR_TITLE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.title')
             echo "| PR | [#${PR_NUMBER}: ${PR_TITLE}](../../pull/${PR_NUMBER}) |" >> "${GITHUB_STEP_SUMMARY}"
           fi
-

--- a/.github/workflows/reuse-triage-failures.yaml
+++ b/.github/workflows/reuse-triage-failures.yaml
@@ -22,10 +22,10 @@ on:
 jobs:
   triage:
     name: Triage Job Failures
-    if: fromJson(inputs.workflow-run).conclusion == 'failure' && fromJson(inputs.workflow-run).run_attempt <= 5
+    if: fromJson(inputs.workflow-run).conclusion == 'failure' && fromJson(inputs.workflow-run).run_attempt <= 2
     runs-on: ubuntu-slim
     permissions:
-      actions: write # required to re-run jobs
+      actions: write # required to rerun jobs
 
     steps:
       - name: Classify failures and retry if infra-related
@@ -40,78 +40,94 @@ jobs:
           REPO=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.repository.full_name')
 
           # Build grep -E pattern from newline-separated input
-          INFRA_PATTERN_RE=$(echo "${INFRA_PATTERNS_INPUT}" | grep -v '^[[:space:]]*$' | paste -sd '|')
+          INFRA_PATTERN_RE=$(printf '%s\n' "${INFRA_PATTERNS_INPUT}" | sed '/^[[:space:]]*$/d' | paste -sd '|')
 
-          echo "==> Triggered by workflow run: ${RUN_ID}"
-          echo "==> Fetching failed jobs..."
+          echo "Triggered by workflow run: ${RUN_ID}"
+          echo "Fetching failed jobs..."
 
           FAILED_JOBS=$(gh api \
             "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
             --jq '[.jobs[] | select(.conclusion == "failure")]')
 
           JOB_COUNT=$(echo "${FAILED_JOBS}" | jq 'length')
-          echo "==> Found ${JOB_COUNT} failed job(s)"
+          echo "Found ${JOB_COUNT} failed job(s)"
 
           if [[ "${JOB_COUNT}" -eq 0 ]]; then
-            echo "==> No failed jobs. Nothing to triage."
+            echo "No failed jobs. Nothing to triage."
             exit 0
           fi
 
-          ALL_INFRA=true
+          HAS_INFRA_ERR=false
+          INFRA_JOB_IDS=()
           SUMMARY=""
 
           while IFS= read -r JOB; do
             JOB_ID=$(echo "${JOB}" | jq -r '.id')
             JOB_NAME=$(echo "${JOB}" | jq -r '.name')
-            echo ""
-            echo "--- Inspecting: ${JOB_NAME} (id=${JOB_ID}) ---"
+            echo -e "\nInspecting: ${JOB_NAME} (id=${JOB_ID})"
 
-            LOGS=$(gh api \
-              "repos/${REPO}/actions/jobs/${JOB_ID}/logs" \
-              || true)
+            LOGS=$(gh api "repos/${REPO}/actions/jobs/${JOB_ID}/logs")
 
-            if echo "${LOGS}" | grep -qE "${INFRA_PATTERN_RE}"; then
-              MATCHED=$(echo "${LOGS}" | grep -oE "${INFRA_PATTERN_RE}" | head -1)
-              echo "==> INFRA failure: '${MATCHED}'"
-              SUMMARY="${SUMMARY}\n- [INFRA]     ${JOB_NAME}: ${MATCHED}"
+            set +o pipefail
+            INFRA_ERR=$(echo "${LOGS}" | grep -oE "${INFRA_PATTERN_RE}" | head -1)
+            set -o pipefail
+
+            if [[ -n "${INFRA_ERR}" ]]; then
+              echo "INFRA failure: '${INFRA_ERR}'"
+              SUMMARY="${SUMMARY}\n- ⚠️ ${JOB_NAME}: ${INFRA_ERR} -> retry"
+              HAS_INFRA_ERR=true
+              INFRA_JOB_IDS+=("${JOB_ID}")
             else
-              echo "==> NON-INFRA failure: will not auto-retry"
-              SUMMARY="${SUMMARY}\n- [NON-INFRA] ${JOB_NAME}: no infra pattern matched"
-              ALL_INFRA=false
+              echo "NON-INFRA failure: will not auto-retry"
+              SUMMARY="${SUMMARY}\n- ❌ ${JOB_NAME}: no infra pattern matched"
             fi
           done < <(echo "${FAILED_JOBS}" | jq -c '.[]')
 
-          echo ""
-          echo "==> Triage summary:"
-          echo -e "${SUMMARY}"
-          echo ""
+          if [[ -n "${SUMMARY}" ]]; then
+            echo "### Summary" >> "${GITHUB_STEP_SUMMARY}"
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+            echo -e "${SUMMARY}" >> "${GITHUB_STEP_SUMMARY}"
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+          fi
 
-          if [[ "${ALL_INFRA}" == "true" ]]; then
-            echo "==> All failures are infrastructure-related. Re-running failed jobs..."
-            gh api \
-              --method POST \
-              "repos/${REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs"
-            echo "==> Re-run triggered."
+          if [[ "${HAS_INFRA_ERR}" == "true" ]]; then
+            echo -e "\nInfrastructure failures detected. Re-running failed jobs..."
+            
+
+            # The /rerun endpoint can be used to rerun a single job, but it does not support multiple jobs in one request.
+            # A subsequent run of a single job can only be triggered once the previous run has completed.
+            #
+            # Rerun all failed jobs:
+            if gh api --method POST "repos/${REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs"; then
+              echo -e "\nSuccessfully triggered rerun for failed jobs"
+
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              echo "> [!NOTE]" >> "${GITHUB_STEP_SUMMARY}"
+              echo "> On a failure, all failed jobs are rerun, not just infra-related ones." >> "${GITHUB_STEP_SUMMARY}"
+            else
+              echo -e "\nFailed to trigger rerun for jobs" >&2
+              exit 1
+            fi
           else
-            echo "==> Non-infrastructure failures present. Skipping auto-retry."
-            echo "==> Manual investigation required."
+            echo "No infrastructure failures detected. Skipping auto-retry."
             exit 1
           fi
 
       - name: Write job summary
         if: always()
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_RUN_JSON: "${{ inputs.workflow-run }}"
+          RUN_NUMBER: ${{ fromJson(inputs.workflow-run).run_number }}
+          RUN_URL: ${{ fromJson(inputs.workflow-run).html_url }}
+          WORKFLOW_NAME: "${{ fromJson(inputs.workflow-run).name }}"
+          AUTHOR: ${{ fromJson(inputs.workflow-run).actor.login }}
+          ATTEMPT: ${{ fromJson(inputs.workflow-run).run_attempt }}
+          HEAD_BRANCH: ${{ fromJson(inputs.workflow-run).head_branch }}
+          HEAD_SHA: ${{ fromJson(inputs.workflow-run).head_sha }}
+          REPO: ${{ fromJson(inputs.workflow-run).repository.full_name }}
         run: |
-          RUN_NUMBER=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.run_number')
-          RUN_URL=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.html_url')
-          WORKFLOW_NAME=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.name')
-          AUTHOR=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.actor.login')
-          ATTEMPT=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.run_attempt')
-          HEAD_BRANCH=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.head_branch')
-          HEAD_SHA=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.head_sha')
-
-          echo "### Triage Details" >> "${GITHUB_STEP_SUMMARY}"
+          echo "### Details" >> "${GITHUB_STEP_SUMMARY}"
           echo "" >> "${GITHUB_STEP_SUMMARY}"
           echo "| Detail | Value |" >> "${GITHUB_STEP_SUMMARY}"
           echo "|--------|-------|" >> "${GITHUB_STEP_SUMMARY}"
@@ -124,9 +140,7 @@ jobs:
           PR_COUNT=$(echo "${WORKFLOW_RUN_JSON}" | jq '.pull_requests | length')
           if [[ "${PR_COUNT}" -gt 0 ]]; then
             PR_NUMBER=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.pull_requests[0].number')
-            PR_TITLE=$(echo "${WORKFLOW_RUN_JSON}" | jq -r '.pull_requests[0].title')
+            PR_TITLE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.title')
             echo "| PR | [#${PR_NUMBER}: ${PR_TITLE}](../../pull/${PR_NUMBER}) |" >> "${GITHUB_STEP_SUMMARY}"
           fi
 
-          echo "" >> "${GITHUB_STEP_SUMMARY}"
-          echo "See the step logs above for the per-job failure classification." >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/reuse-triage-failures.yaml
+++ b/.github/workflows/reuse-triage-failures.yaml
@@ -143,21 +143,25 @@ jobs:
           SUMMARY: ${{ steps.classify.outputs.summary }}
         run: |
           if [[ -n "${SUMMARY}" ]]; then
-            echo "" >> "${GITHUB_STEP_SUMMARY}"
-            echo "### Classification summary" >> "${GITHUB_STEP_SUMMARY}"
-            echo "" >> "${GITHUB_STEP_SUMMARY}"
-            echo -e "${SUMMARY}" >> "${GITHUB_STEP_SUMMARY}"
+            {
+              echo ""
+              echo "### Classification summary"
+              echo ""
+              echo -e "${SUMMARY}"
+            } >> "${GITHUB_STEP_SUMMARY}"
           fi
           
-          echo "### Triage details" >> "${GITHUB_STEP_SUMMARY}"
-          echo "" >> "${GITHUB_STEP_SUMMARY}"
-          echo "| Detail | Value |" >> "${GITHUB_STEP_SUMMARY}"
-          echo "|--------|-------|" >> "${GITHUB_STEP_SUMMARY}"
-          echo "| Workflow | ${WORKFLOW_NAME} |" >> "${GITHUB_STEP_SUMMARY}"
-          echo "| Run Attempt | [${RUN_NUMBER}#${ATTEMPT}](${RUN_URL}?attempt=${ATTEMPT}) |" >> "${GITHUB_STEP_SUMMARY}"
-          echo "| Author | \`${AUTHOR}\` |" >> "${GITHUB_STEP_SUMMARY}"
-          echo "| Branch | \`${HEAD_BRANCH}\` |" >> "${GITHUB_STEP_SUMMARY}"
-          echo "| Commit | [\`${HEAD_SHA:0:7}\`](../../commit/${HEAD_SHA}) |" >> "${GITHUB_STEP_SUMMARY}"
+          {
+            echo "### Triage details"
+            echo ""
+            echo "| Detail | Value |"
+            echo "|--------|-------|"
+            echo "| Workflow | ${WORKFLOW_NAME} |"
+            echo "| Run Attempt | [${RUN_NUMBER}#${ATTEMPT}](${RUN_URL}?attempt=${ATTEMPT}) |"
+            echo "| Author | \`${AUTHOR}\` |"
+            echo "| Branch | \`${HEAD_BRANCH}\` |"
+            echo "| Commit | [\`${HEAD_SHA:0:7}\`](../../commit/${HEAD_SHA}) |"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
           PR_COUNT=$(echo "${WORKFLOW_RUN_JSON}" | jq '.pull_requests | length')
           if [[ "${PR_COUNT}" -gt 0 ]]; then


### PR DESCRIPTION
A reusable workflow that can be called by other workflows to triage failed jobs in a workflow run.

It classifies failed jobs that match certain patterns as infrastructure failures and retries them if a failed job is classified as such.

The retries are limited to a set maximum of attempts per run, currently set to 3. The total number of attempts includes manual retries.

Example caller workflow:
```yaml
# This workflow is to triage failures in other workflow runs
name: Triage Failures

on:
  workflow_run:
    workflows: ['**']
    types: [completed]

permissions:
  actions: write # required to re-run jobs

jobs:
  triage:
    uses: canonical/inference-snaps-dev/.github/workflows/reuse-triage-failures.yml@v2
    with:
      workflow-run: "${{ toJson(github.event.workflow_run) }}"
```
This should be added to the default branch.