### PR TITLE
Add 500 store error to triage workflow

### DIFF
--- a/.github/workflows/reuse-triage-failures.yaml
+++ b/.github/workflows/reuse-triage-failures.yaml
@@ -35,6 +35,7 @@ on:
         default: |
           Status: error while processing
           MAAS reports Failed Deployment
+          Issue encountered while processing your request: [500] Internal Server Error.
 
 jobs:
   triage:


### PR DESCRIPTION
Add `Issue encountered while processing your request: [500] Internal Server Error.` to list of infra errors.

Example failure: https://github.com/canonical/gemma4-snap/actions/runs/30662266309/job/91261027253